### PR TITLE
Add scripts to help use proxied build slaves.

### DIFF
--- a/scripts/enter-proxy-target.sh
+++ b/scripts/enter-proxy-target.sh
@@ -1,0 +1,104 @@
+#!/bin/false
+
+# This file should be sourced, not run.
+
+# When sourced, will attempt to run the current script (that being the script
+# that sourced this one) on the proxy slave, if a login for that slave exists in
+# $HOME/proxy-target.txt. If not, the script does nothing and execution
+# continues on the current host.
+
+# $HOME/proxy-target.txt - If this exists, we are on the proxy host, and the
+# file contains the login to the slave host.  If it doesn't exist, we are on the
+# build slave.
+
+# After figuring that stuff out, this script will run either on_proxy() or
+# on_slave(), depending on which of those is true. Any remaining script commands
+# before this script was sourced are also run, but only on the slave, not on the
+# proxy. Note that commands that were executed *before* this script was sourced
+# will run on both hosts, so make sure this is sourced early.
+
+while pgrep cloud-init >/dev/null 2>&1
+do
+    # Wait until the cloud-init stage is done.
+    sleep 10
+done
+
+if [ -f $HOME/proxy-target.txt ]
+then
+    ret=0
+    on_proxy || ret=$?
+    # Failure to find a function returns 127, so check for that specifically,
+    # otherwise there was an error inside the function.
+    if [ $ret -ne 0 -a $ret -ne 127 ]
+    then
+        exit $ret
+    fi
+    # Else continue.
+
+    login="$(cat $HOME/proxy-target.txt)"
+    # Put our currently executing script on the proxy target.
+    rsync -cze "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" "$0" $login:commands.sh
+    # And the important parts of the environment.
+    for var in \
+        BUILD_CAUSE \
+        BUILD_CAUSE_UPSTREAMTRIGGER \
+        BUILD_DISPLAY_NAME \
+        BUILD_ID \
+        BUILD_NUMBER \
+        BUILD_TAG \
+        BUILD_URL \
+        EXECUTOR_NUMBER \
+        HUDSON_COOKIE \
+        HUDSON_HOME \
+        HUDSON_SERVER_COOKIE \
+        HUDSON_URL \
+        JENKINS_HOME \
+        JENKINS_SERVER_COOKIE \
+        JENKINS_URL \
+        JOB_BASE_NAME \
+        JOB_NAME \
+        JOB_URL \
+        LOGNAME \
+        NODE_LABELS \
+        NODE_NAME \
+        ROOT_BUILD_CAUSE \
+        ROOT_BUILD_CAUSE_MANUALTRIGGER \
+        WORKSPACE \
+        label
+    do
+        eval "echo $var=\\\"\$$var\\\""
+        echo "export $var"
+    done > env.sh
+    rsync -cze "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" env.sh $login:.
+    # And the helper tools, including this script.
+    rsync --delete -czrlpe "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" $HOME/mender-qa $login:.
+    # Copy the workspace. If there is no workspace defined, we are not in the
+    # job section yet.
+    if [ -n "$WORKSPACE" ]
+    then
+        ssh -o BatchMode=yes -o StrictHostKeyChecking=no $login mkdir -p "$WORKSPACE"
+        rsync --delete -czrlpe "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" "$WORKSPACE"/ $login:"$WORKSPACE"/
+    fi
+
+    # Run the actual job.
+    ret=0
+    ssh -o BatchMode=yes -o StrictHostKeyChecking=no $login ". env.sh && cd $WORKSPACE && $HOME/commands.sh" "$@" || ret=$?
+
+    # Copy the workspace back after job has ended.
+    if [ -n "$WORKSPACE" ]
+    then
+        rsync --delete -czrlpe "ssh -o BatchMode=yes -o StrictHostKeyChecking=no" $login:"$WORKSPACE"/ "$WORKSPACE"/
+    fi
+    # Return the error code from the job.
+    exit $ret
+else
+    ret=0
+    on_slave || ret=$?
+    # Failure to find a function returns 127, so check for that specifically,
+    # otherwise there was an error inside the function.
+    if [ $ret -ne 0 -a $ret -ne 127 ]
+    then
+        exit $ret
+    fi
+    # Else continue.
+fi

--- a/scripts/nested-vm.sh
+++ b/scripts/nested-vm.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# A script that launches a nested VM inside an already running VM. The only
+# argument is an image file, which is expected to be accompanied by a KVM xml
+# domain specification with the same name + ".xml". The script also creates a
+# proxy-target.txt file which can be used to automatically enter the host later
+# using enter-proxy-target.sh.
+
+# After the VM is launched, two login ports are available:
+# Port 222  - Login to the proxy. This is equivalent to port 22, but the reason
+#             this is necessary is to stop Jenkins from logging in too early. If
+#             it tries to login too early, it will find the port open, but the
+#             key for the jenkins user might not be accepted yet, and it will
+#             give up. However, if we keep the port closed, it will keep trying.
+# Port 2222 - Login to the proxy target, IOW the build slave. This won't be used
+#             by Jenkins, but is useful for debugging.
+
+set -x -e
+
+if [ -z "$HOME" ]
+then
+    echo "HOME has to be set"
+    exit 1
+fi
+
+if [ -z "$1" ]
+then
+    echo "Requires image name as argument"
+    exit 1
+fi
+
+cp "$1"* $HOME
+
+BASEDISK="$(basename "$1")"
+DISK="$HOME/$BASEDISK"
+XML="$DISK.xml"
+
+# Create an empty file early in case there is an error in this script. At least
+# then we will still detect correctly whether we are on a slave or a proxy.
+touch $HOME/proxy-target.txt
+
+# Enabled nested VMs.
+sudo modprobe -r kvm_intel
+sudo modprobe kvm_intel nested=1
+
+# Verify that nested VMs are supported.
+test "`cat /sys/module/kvm_intel/parameters/nested`" = "Y"
+egrep -q '^flags\b.*\bvmx\b' /proc/cpuinfo
+
+# Install KVM and other tools.
+sudo apt -y update
+sudo apt -y install libvirt-bin rsync
+
+# Enable nbd devices to have partitions.
+sudo modprobe -r nbd
+sudo modprobe nbd max_part=16
+
+# Make temporary keys for logging into nested VM from this host.
+# Saves having to keep the standard private keys here.
+if [ ! -f $HOME/.ssh/id_rsa ]
+then
+    mkdir -p $HOME/.ssh
+    ssh-keygen -f $HOME/.ssh/id_rsa -N ""
+fi
+
+# Mount the image and add some keys.
+sudo qemu-nbd -c /dev/nbd0 $DISK
+sudo mkdir -p /mnt/vm
+success=0
+for i in 1 2 3 4 5
+do
+    sudo mount /dev/nbd0p$i /mnt/vm || continue
+    if [ ! -d /mnt/vm/usr ]
+    then
+       sudo umount /mnt/vm
+       continue
+    fi
+
+    sudo mkdir -p /mnt/vm/root/.ssh
+    sudo bash -c "cat $HOME/.ssh/id_rsa.pub $HOME/.ssh/authorized_keys >> /mnt/vm/root/.ssh/authorized_keys"
+    sudo umount /mnt/vm
+    success=1
+    break
+done
+sudo qemu-nbd -d /dev/nbd0
+
+if [ $success != 1 ]
+then
+    echo "Unable to insert SSH keys"
+    exit 1
+fi
+
+# Replace the disk with our copy.
+sed -i -e "s,[^']*/$BASEDISK,$HOME/$BASEDISK," $XML
+
+chmod go+rx $HOME
+sudo chown libvirt-qemu:libvirt-qemu $DISK $XML
+
+# Start the VM
+sudo virsh net-start default || true
+sudo virsh create $XML
+
+# Find IP of the newly launched host.
+IP=
+attempts=10
+while [ -z "$IP" ]
+do
+    attempts=$(($attempts - 1))
+    if [ $attempts -le 0 ]
+    then
+        echo "Could not find IP of launched VM."
+        exit 1
+    fi
+
+    sleep 10
+    IP="$(sudo arp | grep virbr0 | awk '{print $1}')"
+done
+echo "jenkins@$IP" > $HOME/proxy-target.txt
+
+# Port forward to this host on port 222, and new host on port 2222.
+sudo iptables -t nat -I PREROUTING 1 -p tcp --dport 222 -j DNAT --to-dest :22
+sudo iptables -t nat -I OUTPUT 1 -p tcp --dst 127.0.0.1 --dport 222 -j DNAT --to-dest :22
+sudo iptables -t nat -I PREROUTING 1 -p tcp --dport 2222 -j DNAT --to-dest $IP:22
+sudo iptables -t nat -I OUTPUT 1 -p tcp --dst 127.0.0.1 --dport 2222 -j DNAT --to-dest $IP:22
+sudo iptables -I FORWARD 1 -p tcp --dport 22 -j ACCEPT
+
+# Create jenkins user on slave VM and copy keys.
+attempts=10
+while ! ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP true
+do
+    attempts=$(($attempts - 1))
+    if [ $attempts -le 0 ]
+    then
+        echo "Could not connect to SSH of launched VM."
+        exit 1
+    fi
+
+    sleep 10
+done
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP useradd -m -d /home/jenkins jenkins || true
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP mkdir -p /home/jenkins/.ssh
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP cp .ssh/authorized_keys /home/jenkins/.ssh/authorized_keys
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP chown -R jenkins:jenkins /home/jenkins/.ssh
+ssh -o BatchMode=yes -o StrictHostKeyChecking=no root@$IP "apt-get -y update && apt-get -y install rsync"
+
+exit 0


### PR DESCRIPTION
nested-vm.sh launches a nested VM within an existing VM, which gives
the ability to use very old OSes.

enter-proxy-target.sh should be sourced from the build recipe in order
to execute the recipe on the correct host.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>