### PR TITLE
Upgrade configuration according to krogoth standard.

### DIFF
--- a/build-conf/bblayers.conf
+++ b/build-conf/bblayers.conf
@@ -1,18 +1,14 @@
-# LAYER_CONF_VERSION is increased each time build/conf/bblayers.conf
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
 # changes incompatibly
-LCONF_VERSION = "6"
+POKY_BBLAYERS_CONF_VERSION = "2"
 
 BBPATH = "${TOPDIR}"
 BBFILES ?= ""
 
 BBLAYERS ?= " \
   /home/jenkins/workspace/yoctobuild/meta \
-  /home/jenkins/workspace/yoctobuild/meta-yocto \
+  /home/jenkins/workspace/yoctobuild/meta-poky \
   /home/jenkins/workspace/yoctobuild/meta-yocto-bsp \
   /home/jenkins/workspace/yoctobuild/meta-mender \
   /home/jenkins/workspace/yoctobuild/oe-meta-go \
-  "
-BBLAYERS_NON_REMOVABLE ?= " \
-  /home/jenkins/workspace/yoctobuild/meta \
-  /home/jenkins/workspace/yoctobuild/meta-yocto \
   "

--- a/build-conf/templateconf.cfg
+++ b/build-conf/templateconf.cfg
@@ -1,0 +1,1 @@
+meta-poky/conf


### PR DESCRIPTION
This fixes a very elusive bug where you would get a "taskhash
mismatch" error the first time you build using an old config file. The
reason is that poky would auto-upgrade the file behind your back, and
this would cause taskhash calculations to somehow get out of sync. We
would get this error every time in Jenkins because we always start
with a freshly checked out file from this repository.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>