### PR TITLE
Remove syncing of build artifact cache.

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -230,32 +230,6 @@ then
         label=${NODE_LABELS%% *}
     fi
 
-    # Copy the build cache, if there is one, and only if the node has a known
-    # label.
-    if [ x"$label" != x ]
-    then
-
-        # Clean up spurious garbage
-        find $HOME/.cache/*/ -type f -size 0  |  xargs rm -f
-
-        if [ -d $HOME/.cache/cfengine-buildscripts-distfiles ]
-        then
-            $RSH  $login  mkdir -p .cache
-            $RSYNC -e "$RSH"                                        \
-                   $HOME/.cache/cfengine-buildscripts-distfiles/    \
-                  $login:.cache/cfengine-buildscripts-distfiles/
-        fi
-
-        if [ -d $HOME/.cache/cfengine-buildscripts-pkgs ]
-        then
-            mkdir -p $HOME/.cache/cfengine-buildscripts-pkgs/$label
-            $RSH  $login  mkdir -p .cache/cfengine-buildscripts-pkgs/$label
-            $RSYNC -e "$RSH"                                          \
-                   $HOME/.cache/cfengine-buildscripts-pkgs/$label/    \
-                  $login:.cache/cfengine-buildscripts-pkgs/$label/
-        fi
-    fi
-
     # --------------------------------------------------------------------------
     # Run the actual job.
     # --------------------------------------------------------------------------
@@ -273,29 +247,6 @@ then
     if [ -n "$WORKSPACE" ]
     then
         $RSYNC -e "$RSH"    $login:"$WORKSPACE_REMOTE"/  "$WORKSPACE"/
-    fi
-
-    # Copy the build cache back in order to be preserved.
-    if [ x"$label" != x ]
-    then
-
-        # Clean up spurious garbage
-        $RSH $login \
-             "find .cache/*/ -type f -size 0  |  xargs rm -f"
-
-        if [ -d $HOME/.cache/cfengine-buildscripts-distfiles ]
-        then
-            $RSYNC -e "$RSH"                                       \
-                   $login:.cache/cfengine-buildscripts-distfiles/  \
-                    $HOME/.cache/cfengine-buildscripts-distfiles/
-        fi
-
-        if [ -d $HOME/.cache/cfengine-buildscripts-pkgs ]
-        then
-            $RSYNC -e "$RSH"                                         \
-                   $login:.cache/cfengine-buildscripts-pkgs/$label/  \
-                    $HOME/.cache/cfengine-buildscripts-pkgs/$label/
-        fi
     fi
 
     # Return the error code from the job.


### PR DESCRIPTION
It causes too many problems in practice, with several hosts trying to
sync to one directory at a time.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>