### PR TITLE
Make sure we are really picking the qemu-system-arm, not bitbake one.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -82,7 +82,7 @@ EOF
 
     export UBOOT_ELF=$WORKSPACE/vexpress-qemu/u-boot.elf
     export VEXPRESS_SDIMG=$WORKSPACE/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.sdimg
-    export QEMU_SYSTEM_ARM="qemu-system-arm"
+    export QEMU_SYSTEM_ARM="/usr/bin/qemu-system-arm"
     cp $WORKSPACE/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 image.dat
 
     mender-artifact write rootfs-image -t vexpress-qemu -n test-update -u $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 -o successful_image_update.mender


### PR DESCRIPTION
Since bitbake is now first in the path, this takes precedence unless
we use full path.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>