### PR TITLE
Artifact publication

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -88,7 +88,7 @@ EOF
     then
     # store useful output to directory
     mkdir -p "vexpress-qemu-deploy"
-        mv $BUILDDIR/tmp/deploy/* "vexpress-qemu-deploy"
+        cp -r $BUILDDIR/tmp/deploy/* "vexpress-qemu-deploy"
     fi
 
     PATH="$OLD_PATH"
@@ -145,7 +145,7 @@ EOF
     then
         cd $WORKSPACE/
         mkdir -p "beaglebone-deploy"
-        mv $BUILDDIR/tmp/deploy/* "beaglebone-deploy"
+        cp -r $BUILDDIR/tmp/deploy/* "beaglebone-deploy"
     fi
 
     PATH="$OLD_PATH"

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -162,12 +162,20 @@ fi
 
 
 if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
-    cd /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-qemu
-    cp ../core-image-full-cmdline-vexpress-qemu.ext4 ../core-image-full-cmdline-vexpress-qemu.sdimg ../u-boot.elf .
+    cd $WORKSPACE
+    # Set build dir for qemu again, BBB build might possibly have overridden
+    # this.
+    source oe-init-build-env build-qemu
 
-    s3cmd -F put core-image-full-cmdline-vexpress-qemu.ext4 s3://mender/temp/core-image-full-cmdline-vexpress-qemu.ext4
-    s3cmd setacl s3://mender/temp/core-image-full-cmdline-vexpress-qemu.ext4 --acl-public
+    cd $WORKSPACE/meta-mender/meta-mender-qemu
+    cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.{ext4,sdimg} .
+    cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/u-boot.elf .
 
     sudo docker build -t mendersoftware/mender-client-qemu:latest --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf .
     cd $WORKSPACE/integration/tests && sudo ./run.sh
+
+    if [ $PUBLISH_ARTIFACTS = "true" ]; then
+        s3cmd -F put core-image-full-cmdline-vexpress-qemu.ext4 s3://mender/temp/core-image-full-cmdline-vexpress-qemu.ext4
+        s3cmd setacl s3://mender/temp/core-image-full-cmdline-vexpress-qemu.ext4 --acl-public
+    fi
 fi


### PR DESCRIPTION
```
commit 298855e01e59b856fc2c6ea886275f3d26f1f6df
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Mon Feb 6 15:30:47 2017

    yoctobuild: Improve artifact upload process.
    
    - Move artifact upload to after tests.
    - Switch build directory to QEMU before running integration tests.
      This is so that sub scripts will pick up artifacts from this
      directory.
    - Make artifact publication dependent on PUBLISH_ARTIFACTS variable.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>

commit 2c4dd25dadf1b9ad2b19a0b6c469a7a87fec2663
Author: Kristian Amlie <kristian.amlie@mender.io>
Date:   Mon Feb 6 15:23:11 2017

    Keep build directory intact, other components look for it.
    
    The run.sh script only downloads an artifact from S3 if it can't find
    one in the current build directory, but because we moved it, this
    would always happen. We want it to use the one we just built.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
```