### PR TITLE
Fix emergency mode error when testing meta-mender:master.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -226,8 +226,8 @@ EOF
         s3cmd setacl s3://mender/${RELEASE_VERSION}/beaglebone/beaglebone_release_1.mender --acl-public
         s3cmd setacl s3://mender/${RELEASE_VERSION}/beaglebone/beaglebone_release_2.mender --acl-public
 
-        sudo docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
-        sudo docker tag mendersoftware/mender-client-qemu:pr mendersoftware/mender-client-qemu:${RELEASE_VERSION}
-        sudo docker push mendersoftware/mender-client-qemu:${RELEASE_VERSION}
+        docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+        docker tag mendersoftware/mender-client-qemu:pr mendersoftware/mender-client-qemu:${RELEASE_VERSION}
+        docker push mendersoftware/mender-client-qemu:${RELEASE_VERSION}
     fi
 fi

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -193,8 +193,14 @@ if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
     cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.{ext4,sdimg} .
     cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/u-boot.elf .
 
-    docker build -t mendersoftware/mender-client-qemu:latest --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf .
-    cd $WORKSPACE/integration/tests && ./run.sh
+    docker build -t mendersoftware/mender-client-qemu:pr --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf .
+    cat > $WORKSPACE/integration/docker-compose-pr-client.yml <<EOF
+version: '2'
+services:
+    mender-client:
+        image: mendersoftware/mender-client-qemu:pr
+EOF
+    cd $WORKSPACE/integration/tests && ./run.sh --docker-compose-file=../docker-compose-pr-client.yml
 
     if [ -n "$RELEASE_VERSION" ]; then
         s3cmd -F put core-image-full-cmdline-vexpress-qemu.ext4 s3://mender/temp_${RELEASE_VERSION}/core-image-full-cmdline-vexpress-qemu.ext4
@@ -221,7 +227,7 @@ if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
         s3cmd setacl s3://mender/${RELEASE_VERSION}/beaglebone/beaglebone_release_2.mender --acl-public
 
         sudo docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
-        sudo docker tag mendersoftware/mender-client-qemu:latest mendersoftware/mender-client-qemu:${RELEASE_VERSION}
+        sudo docker tag mendersoftware/mender-client-qemu:pr mendersoftware/mender-client-qemu:${RELEASE_VERSION}
         sudo docker push mendersoftware/mender-client-qemu:${RELEASE_VERSION}
     fi
 fi


### PR DESCRIPTION
When we build the docker container for the client, we refer to
latest. However, docker-compose will refer to a specific tag,
depending on which branch we're building. In order to avoid having to
look inside the file for this information, or doing a complicated Git
query to try to figure out the Git branch (which is not even
guaranteed to match the tag in the docker-compose file), we force the
tag by passing in a docker-compose file that overrides the first one.

This fixes a problem where the wrong container was used for testing
the client.