### PR TITLE
Do not require native SDL to build vexpress-qemu builds.

### DIFF
--- a/build-conf/local.conf
+++ b/build-conf/local.conf
@@ -232,9 +232,9 @@ BB_DISKMON_DIRS = "\
 # By default qemu will build with a builtin VNC server where graphical output can be
 # seen. The two lines below enable the SDL backend too. This assumes there is a
 # libsdl library available on your build system.
-PACKAGECONFIG_append_pn-qemu-native = " sdl"
-PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
-ASSUME_PROVIDED += "libsdl-native"
+#PACKAGECONFIG_append_pn-qemu-native = " sdl"
+#PACKAGECONFIG_append_pn-nativesdk-qemu = " sdl"
+#ASSUME_PROVIDED += "libsdl-native"
 
 
 # CONF_VERSION is increased each time build/conf/ changes incompatibly and is used to


### PR DESCRIPTION
This gets rid of several problems, first of all this message, if
libSDL is not installed:

---
ERROR: OE-core's config sanity checker detected a potential
misconfiguration.
Either fix the cause of this error or at your own risk disable the
checker (see sanity.conf).
Following is the list of potential problems / advisories:
libsdl-native is set to be ASSUME_PROVIDED but sdl-config can't be
found in PATH. Please either install it, or configure qemu not to
require sdl.
---

And also, even if you have that library installed, it's easy to get
into a misconfiguration situation where you compile against a native
library, but while running, it chooses a different library, or vice
versa. libcaca is a prime example of this, which is an indirect
dependency of libSDL through ncurses. The one on Ubuntu 16 is not
compatible with the one in Yocto.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>