### PR TITLE
Remove oe-meta-go dependency for all non-morty branches.

### DIFF
--- a/build-conf/bblayers.conf
+++ b/build-conf/bblayers.conf
@@ -13,5 +13,4 @@ BBLAYERS ?= " \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-demo \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-qemu \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-beaglebone \
-  /home/jenkins/workspace/yoctobuild/oe-meta-go \
   "

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -61,6 +61,14 @@ PREFERRED_VERSION_mender-artifact = "master-git%"
 PREFERRED_VERSION_mender-artifact-native = "master-git%"
 EOF
     fi
+
+    # Figure out which branch of poky we're building.
+    if egrep -q '^ *DISTRO_CODENAME *= *"morty" *$' $WORKSPACE/meta-poky/conf/distro/poky.conf; then
+        # Morty needs oe-meta-go
+        cat >> $BUILDDIR/conf/bblayers.conf <<EOF
+BBLAYERS_append = " /home/jenkins/workspace/yoctobuild/oe-meta-go"
+EOF
+    fi
 }
 
 if [ "$CLEAN_BUILD_CACHE" = "true" ]

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -28,9 +28,9 @@ prepare_and_set_PATH() {
     # because the prepare_recipe_sysroot task doesn't exist. Use that failure
     # to fall back to the old generic sysroot path.
     if bitbake -c prepare_recipe_sysroot mender-test-dependencies; then
-        eval `bitbake -e mender-test-dependencies | grep '^export PATH='`
+        eval `bitbake -e mender-test-dependencies | grep '^export PATH='`:$PATH
     else
-        eval `bitbake -e core-image-minimal | grep '^export PATH='`
+        eval `bitbake -e core-image-minimal | grep '^export PATH='`:$PATH
     fi
 }
 


### PR DESCRIPTION
poky/master has OOTB Go support now.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>