### PR TITLE
Double the waiting time to get IP of nested VM

### DIFF
--- a/scripts/nested-vm.sh
+++ b/scripts/nested-vm.sh
@@ -136,7 +136,7 @@ sudo virsh create $XML
 
 # Find IP of the newly launched host.
 IP=
-attempts=10
+attempts=20
 while [ -z "$IP" ]
 do
     attempts=$(($attempts - 1))


### PR DESCRIPTION
Due to flaky performance of DO droplets, we sometimes need to wait longer for the nested VM to boot.