### PR TITLE
Fix error when resetting docker-compose files with Git.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -237,7 +237,7 @@ if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
 
     # Reset docker tag names to their cloned values after tests are done.
     cd $WORKSPACE/integration
-    git checkout -- docker-compose*.yml
+    git checkout -f -- .
 
     if [ "$PUSH_CONTAINERS" = true ]; then
         CLIENT_VERSION=$($WORKSPACE/integration/extra/release_tool.py --version-of mender)


### PR DESCRIPTION
The problem is that the tests will create some extra files that also
match the pattern, and Git will complain when it doesn't find these in
the index. Solve this by simply checking out everything instead.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>