### PR TITLE
Be verbose when running meta-mender QEMU tests.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -167,7 +167,7 @@ then
             echo "WARNING: install pytest-html for html results report"
         fi
 
-        py.test --junit-xml=results.xml $HTML_REPORT || FAILED=1
+        py.test --verbose --junit-xml=results.xml $HTML_REPORT || FAILED=1
 
         if [ ! -z "$PR_TO_TEST" ]; then
             HTML_REPORT=$(find . -iname report.html  | head -n 1)


### PR DESCRIPTION
Makes it easier to see where PASSED and FAILED occurs in the output.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>