### PR TITLE
Fix non-runnable mender-artifact being uploaded.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -10,6 +10,7 @@ ls /home/jenkins/.ssh
 
 PR_COMMENT_ENDPOINT=https://api.github.com/repos/mendersoftware/$REPO_TO_TEST/issues/$PR_TO_TEST/comments
 PR_STATUS_ENDPOINT=https://api.github.com/repos/mendersoftware/$REPO_TO_TEST/statuses/$GIT_COMMIT
+export PATH=$PATH:~/workspace/yoctobuild/go/bin
 
 declare -A TEST_TRACKER
 


### PR DESCRIPTION
Yocto inserts some incompatible dynamic loader library into the binary
that makes it useless outside of the Yocto context. So build our own
version of mender-artifact instead and upload that.

Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>