### PR TITLE
Get rid of confusing 'fatal: no tag exactly matches...' message.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -128,8 +128,8 @@ SSTATE_DIR = "/mnt/sstate-cache"
 MENDER_ARTIFACT_NAME = "mender-image-$CLIENT_VERSION"
 EOF
 
-    mender_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender && git describe --tags --exact-match HEAD) || mender_on_exact_tag=
-    mender_artifact_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && git describe --tags --exact-match HEAD) || mender_artifact_on_exact_tag=
+    mender_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender && git describe --tags --exact-match HEAD 2>/dev/null) || mender_on_exact_tag=
+    mender_artifact_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && git describe --tags --exact-match HEAD 2>/dev/null) || mender_artifact_on_exact_tag=
 
     # Setting these PREFERRED_VERSIONs doesn't influence which version we build,
     # since we are building the one that Jenkins has cloned, but it does


### PR DESCRIPTION
This is harmless and in fact quite normal. All non-release builds will
exhibit this.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>