### PR TITLE
Remove unneeded meta-openembedded layer.

### DIFF
--- a/build-conf-rpi3/bblayers.conf
+++ b/build-conf-rpi3/bblayers.conf
@@ -13,9 +13,9 @@ BBLAYERS ?= " \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-demo \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-raspberrypi \
   /home/jenkins/workspace/yoctobuild/meta-raspberrypi \
-  /home/jenkins/workspace/yoctobuild/meta-openembedded/meta-oe \
-  /home/jenkins/workspace/yoctobuild/meta-openembedded/meta-multimedia \
-  /home/jenkins/workspace/yoctobuild/meta-openembedded/meta-networking \
-  /home/jenkins/workspace/yoctobuild/meta-openembedded/meta-python \
+  /home/jenkins/workspace/yoctobuild/meta-oe \
+  /home/jenkins/workspace/yoctobuild/meta-multimedia \
+  /home/jenkins/workspace/yoctobuild/meta-networking \
+  /home/jenkins/workspace/yoctobuild/meta-python \
  "
 


### PR DESCRIPTION
It is a strict subset of poky.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>