### PR TITLE
Make sure meta-mender-ci is included in all builds.

### DIFF
--- a/build-conf-bbb/bblayers.conf
+++ b/build-conf-bbb/bblayers.conf
@@ -11,6 +11,4 @@ BBLAYERS ?= " \
   /home/jenkins/workspace/yoctobuild/meta-yocto-bsp \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-core \
   /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-demo \
-  /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-qemu \
-  /home/jenkins/workspace/yoctobuild/meta-mender/meta-mender-beaglebone \
   "

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -420,19 +420,19 @@ then
             echo "WARNING: install pytest-html for html results report"
         fi
 
-        github_pull_request_status "pending" "qemu-raw-flash acceptance tests started in Jenkins" \
-                                   "$BUILD_URL" "qemu_flash_acceptance_tests"
+        github_pull_request_status "pending" "qemu-raw-flash build started in Jenkins" \
+                                   "$BUILD_URL" "qemu_flash_build"
 
         bitbake-layers add-layer "$WORKSPACE"/meta-mender/tests/meta-mender-ci
 
         bitbake core-image-minimal || QEMU_BITBAKE_RESULT=$?
         if [ $QEMU_BITBAKE_RESULT -ne 0 ]; then
-            github_pull_request_status "failure" "qemu-raw-flash acceptance tests failed" \
-                                       $REPORT_URL "qemu_flash_acceptance_tests"
+            github_pull_request_status "failure" "qemu-raw-flash build failed" \
+                                       "$BUILD_URL" "qemu_flash_build"
             exit $QEMU_BITBAKE_RESULT
         else
-            github_pull_request_status "success" "qemu-raw-flash acceptance tests passed!" \
-                                       $REPORT_URL "qemu_flash_acceptance_tests"
+            github_pull_request_status "success" "qemu-raw-flash build passed!" \
+                                       "$BUILD_URL" "qemu_flash_build"
         fi
 
         cd $WORKSPACE/meta-mender/tests/acceptance/

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -531,7 +531,7 @@ then
         mender-artifact write rootfs-image -t beaglebone -n test-update -u "$BUILDDIR"/tmp/deploy/images/beaglebone/core-image-base-beaglebone.ext4 -o successful_image_update.mender
         github_pull_request_status "pending" "Beaglebone acceptance tests started" "$BUILD_URL" "beaglebone_acceptance_tests"
         STATUS=0
-        pytest --host=${SSH_TUNNEL_IP}:${BBB_PORT} --board-type=bbb || STATUS=$?
+        pytest --verbose --host=${SSH_TUNNEL_IP}:${BBB_PORT} --board-type=bbb || STATUS=$?
         if [[ $STATUS -eq 0 ]]; then
             github_pull_request_status "success" "Beaglebone acceptance tests completed" "$BUILD_URL" "beaglebone_acceptance_tests"
         else
@@ -620,7 +620,7 @@ then
         mender-artifact write rootfs-image -t raspberrypi3 -n test-update -u "$WORKSPACE"/build-rpi3/tmp/deploy/images/raspberrypi3/core-image-full-cmdline-raspberrypi3.ext4 -o successful_image_update.mender
         github_pull_request_status "pending" "Raspberry Pi 3 acceptance tests started" "$BUILD_URL" "rpi3_acceptance_tests"
         STATUS=0
-        pytest --host=${SSH_TUNNEL_IP}:${RPI3_PORT} --board-type=rpi3 || STATUS=$?
+        pytest --verbose --host=${SSH_TUNNEL_IP}:${RPI3_PORT} --board-type=rpi3 || STATUS=$?
         if [[ $STATUS -eq 0 ]]; then
             github_pull_request_status "success" "Raspberry Pi 3 acceptance tests completed" "$BUILD_URL" "rpi3_acceptance_tests"
         else


### PR DESCRIPTION
Also reorder file copying so that the vanilla non-ci version is the
one that is kept.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>