### PR TITLE
Add RELEASE_BUILD to the list of blessed variables for proxy setup

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -238,6 +238,7 @@ then
         NODE_LABELS \
         NODE_NAME \
         NO_TESTS \
+        RELEASE_BUILD \
         ROOT_BUILD_CAUSE \
         ROOT_BUILD_CAUSE_MANUALTRIGGER \
         WORKSPACE \


### PR DESCRIPTION
This is a new parameter that is removed unless added to the
special list.