### PR TITLE
Don't require running integration tests to push artifacts.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -709,16 +709,6 @@ run_integration_tests() {
         if [ "$testing_status" -ne 0 ]; then
             exit $testing_status
         fi
-
-        if [ "$PUBLISH_ARTIFACTS" = true ]; then
-            docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
-
-            for container in mender-client-qemu api-gateway deployments deviceadm deviceauth gui inventory useradm; do
-                local version=$($WORKSPACE/integration/extra/release_tool.py --version-of $container)
-                docker tag mendersoftware/$container:pr mendersoftware/$container:${version}
-                docker push mendersoftware/$container:${version}
-            done
-        fi
     )
 }
 
@@ -740,4 +730,14 @@ fi
 
 if [ "$RUN_INTEGRATION_TESTS" = "true" ]; then
     run_integration_tests
+fi
+
+if [ "$PUBLISH_ARTIFACTS" = true ] && [ "$BUILD_QEMU_SDIMG" = true ]; then
+    docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+
+    for container in mender-client-qemu api-gateway deployments deviceadm deviceauth gui inventory useradm; do
+        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $container)
+        docker tag mendersoftware/$container:pr mendersoftware/$container:${version}
+        docker push mendersoftware/$container:${version}
+    done
 fi


### PR DESCRIPTION
It's nice to require it in theory. In practice, we can't always wait
for them, and we might already know that they pass.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>