### PR TITLE
Force rsync installation even ignoring certificate

### DIFF
--- a/scripts/nested-vm.sh
+++ b/scripts/nested-vm.sh
@@ -182,7 +182,7 @@ $RSH root@$IP  "mkdir -p /home/jenkins/.ssh"
 $RSH root@$IP  "cp .ssh/authorized_keys /home/jenkins/.ssh/authorized_keys"
 scp -o BatchMode=yes  /home/jenkins/.ssh/id_rsa* root@$IP:/home/jenkins/.ssh/
 $RSH root@$IP  "chown -R jenkins:jenkins /home/jenkins/.ssh"
-PKG_MANAGER="apt-get -q"
+PKG_MANAGER="apt-get -q --force-yes"
 $RSH root@$IP  "test -x /usr/bin/yum"  &&  PKG_MANAGER=yum
 $RSH root@$IP  "$PKG_MANAGER -y update && $PKG_MANAGER -y install rsync"
 


### PR DESCRIPTION
This is needed for some old platforms like Debian 6 with expired repository
keys.

Signed-off-by: Aleksei Shpakovskii <aleksei.shpakovskii@cfengine.com>