### PR TITLE
Updated go and docker version for build slaves

### DIFF
--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -4,23 +4,25 @@ cd $HOME
 
 . mender-qa/scripts/initialize-build-host.sh
 
-sudo curl -L https://github.com/docker/compose/releases/download/1.16.1/docker-compose-`uname -s`-`uname -m` > docker-compose
+sudo curl -L https://github.com/docker/compose/releases/download/1.20.1/docker-compose-`uname -s`-`uname -m` > docker-compose
 
 sudo cp docker-compose /usr/bin/docker-compose
 sudo chmod +x /usr/bin/docker-compose
 
 sudo chown jenkins:jenkins /usr/bin/docker-compose
 
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get -qy update
 echo "deb http://apt.dockerproject.org/repo debian-jessie main" | sudo tee -a /etc/apt/sources.list.d/docker.list
 curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
 sudo apt-get -qy update
-sudo apt-get -qy --force-yes install git autoconf automake build-essential diffstat gawk chrpath libsdl1.2-dev e2tools nfs-client  s3cmd docker-engine psmisc screen libssl-dev python-dev libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo default-jre-headless pkg-config zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler
+sudo apt-get -qy --force-yes install git autoconf automake build-essential diffstat gawk chrpath libsdl1.2-dev e2tools nfs-client  s3cmd docker-ce psmisc screen libssl-dev python-dev libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo default-jre-headless pkg-config zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler
 
 sudo cp /sbin/debugfs /usr/bin/ || echo "debugfs not in /sbin/"
 
-wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
-gunzip -c go1.8.linux-amd64.tar.gz | (cd /usr/local && sudo tar x)
+wget https://storage.googleapis.com/golang/go1.10.linux-amd64.tar.gz
+gunzip -c go1.10.linux-amd64.tar.gz | (cd /usr/local && sudo tar x)
 sudo ln -sf ../go/bin/go /usr/local/bin/go
 sudo ln -sf ../go/bin/godoc /usr/local/bin/godoc
 sudo ln -sf ../go/bin/gofmt /usr/local/bin/gofmt


### PR DESCRIPTION
Updated go to 1.10 and docker-compose to 1.20.1

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>