### PR TITLE
Set GitHub PR status on proxied jobs

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -315,6 +315,11 @@ then
                 ;;
         esac
     done > env.sh
+
+    # make it easy to check if running in a proxied target
+    echo "PROXIED=1" >> env.sh
+    echo "export PROXIED" >> env.sh
+
     $RSYNC -e "$RSH"    env.sh  $login:.
 
     # And the helper tools, including this script.


### PR DESCRIPTION
The proxied jenkins jobs usually don't allow "fancy" things like posting results to GitHub over HTTPS. The proxy can, however, do the job quite easily instead.