### PR TITLE
Switch GRUB/BIOS combination to new machine name to avoid conflict.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -898,7 +898,7 @@ if is_poky_branch morty || is_poky_branch pyro || is_poky_branch rocko; then
 else
     beaglebone_machine_name=beaglebone-yocto
 
-    add_to_build_list  qemux86-64                qemux86-64-bios-grub  core-image-full-cmdline
+    add_to_build_list  mender-qemux86-64-bios    qemux86-64-bios-grub  core-image-full-cmdline
 fi
 
 add_to_build_list      qemux86-64                qemux86-64-uefi-grub  core-image-full-cmdline


### PR DESCRIPTION
Machine names that are equal should reflect images that are
compatible, but this is not true for GRUB/UEFI vs GRUB/BIOS, due to
the mount point of the environment being different (/boot/efi vs
/boot/grub). So switch to a new machine name to distinguish between
the two configurations.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>