### PR TITLE
delete remote workspace before copying workspace to proxy target

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -331,6 +331,7 @@ then
     # job section yet.
     if [ -n "$WORKSPACE" ]
     then
+        $RSH  $login  sudo rm -rf "$WORKSPACE_REMOTE" || true
         $RSH  $login  mkdir -p "$WORKSPACE_REMOTE"
         $RSYNC -e "$RSH"    "$WORKSPACE"/  $login:"$WORKSPACE_REMOTE"/
     fi


### PR DESCRIPTION
This slightly increases time it takes to transfer everything to remote machine, but saves us from permission errors which could sometimes lead to build failures.