### PR TITLE
Fix corner case when master is exactly on a tag with no recipe.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -275,8 +275,8 @@ EOF
 MENDER_ARTIFACT_NAME = "mender-image-$client_version"
 EOF
 
-    local mender_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender && git describe --tags --exact-match HEAD 2>/dev/null) || mender_on_exact_tag=
-    local mender_artifact_on_exact_tag=$(cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && git describe --tags --exact-match HEAD 2>/dev/null) || mender_artifact_on_exact_tag=
+    local mender_on_exact_tag=$(test "$MENDER_REV" != "master" && cd $WORKSPACE/go/src/github.com/mendersoftware/mender && git describe --tags --exact-match HEAD 2>/dev/null) || mender_on_exact_tag=
+    local mender_artifact_on_exact_tag=$(test "$MENDER_ARTIFACT_REV" != "master" && cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && git describe --tags --exact-match HEAD 2>/dev/null) || mender_artifact_on_exact_tag=
 
     # Setting these PREFERRED_VERSIONs doesn't influence which version we build,
     # since we are building the one that Jenkins has cloned, but it does


### PR DESCRIPTION
This is quite a rare corner case:

1. master of the affected client repository must point exactly at a
   tag, IOW master has not moved since the release was made

2. The branch being built must not have a recipe for this tag

3. The checksum of the license file must be different in the most
   recent version of the recipe that the branch does have, when
   compared to master

What happens then is that we try to set PREFERRED_VERSION to the
version from the tag. However Yocto doesn't find that version and
instead tries to use the most recent versioned recipe, but *not* the
Git recipe, which is what we want it to do.

So just make an exception if the REV variables say "master", since we
always want the Git recipe in this case.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>