### PR TITLE
Install kpartx package.

### DIFF
--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -17,7 +17,7 @@ sudo apt-get -qy update
 echo "deb http://apt.dockerproject.org/repo debian-jessie main" | sudo tee -a /etc/apt/sources.list.d/docker.list
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -
 sudo apt-get -qy update
-sudo apt-get -qy --force-yes install git autoconf automake build-essential diffstat gawk chrpath libsdl1.2-dev e2tools nfs-client  s3cmd psmisc screen libssl-dev python-dev libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo default-jre-headless pkg-config zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler qemu-system-x86 bc
+sudo apt-get -qy --force-yes install git autoconf automake build-essential diffstat gawk chrpath libsdl1.2-dev e2tools nfs-client  s3cmd psmisc screen libssl-dev python-dev libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo default-jre-headless pkg-config zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler qemu-system-x86 bc kpartx
 sudo apt-get -qy --force-yes install docker-ce || sudo apt-get -qy --force-yes install docker-ce
 sudo cp /sbin/debugfs /usr/bin/ || echo "debugfs not in /sbin/"
 


### PR DESCRIPTION
kpartx package is necessary for mender conversion scripts.

Signed-off-by: Dominik Adamski <adamski.dominik@gmail.com>