### PR TITLE
Load some acceptence tests from mender-image-tests repo

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -712,6 +712,9 @@ build_and_test_client() {
 
             cd $WORKSPACE/meta-mender/tests/acceptance/
 
+            # Add mutual tests for non-Yocto & Yocto builds.
+            cp -t . $WORKSPACE/mender-image-tests/tests/*
+
             local acceptance_test_to_run=""
 
             # make it possible to run specific test


### PR DESCRIPTION
Mutual acceptance tests for Yocto & non-Yocto built images
are kept in a separate repository called mender-image-tests.

Issues: MEN-2099

Signed-off-by: Adam Podogrocki <a.podogrocki@gmail.com>