### PR TITLE
Keep tests in meta-mender if they conflict with mender-image-tests.

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -714,7 +714,7 @@ build_and_test_client() {
             cd $WORKSPACE/meta-mender/tests/acceptance/
 
             # Add mutual tests for non-Yocto & Yocto builds.
-            cp -t . $WORKSPACE/mender-image-tests/tests/*
+            cp -n $WORKSPACE/mender-image-tests/tests/* .
 
             local acceptance_test_to_run=""
 


### PR DESCRIPTION
Typically this is because it is an older branch.

Also get rid of the 'cp -t' argument which causes a quite uncommon and
somewhat confusing order of arguments.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>