### PR TITLE
changelog: run both ST and MT backend tests

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -154,7 +154,7 @@ EOF
             local pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
 
             set -x
-            curl --user "$GITHUB_BOT_USER:$GITHUB_BOT_PASSWORD" \
+            curl -iv --user "$GITHUB_BOT_USER:$GITHUB_BOT_PASSWORD" \
                  -d "$request_body" \
                  "$pr_status_endpoint"
             set +x

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -960,7 +960,7 @@ run_backend_integration_tests() {
         local testing_status=0
 
         cd $WORKSPACE/integration/backend-tests && \
-           PYTEST_ARGS="-k Multitenant" ./run -f=../docker-compose.tenant.yml -f=../docker-compose.mt.yml -f=../docker-compose.storage.minio.yml || \
+           PYTEST_ARGS="-k 'not Multitenant'" ./run || \
            testing_status=$?
 
         if [ $testing_status -ne 0 ]; then

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -627,7 +627,7 @@ build_and_test() {
     fi
 
     if [ "$machine_to_build" = "mender_servers" ]; then
-        run_backend_integration_tests
+        run_backend_integration_tests && \
         run_integration_tests
     else
         run_integration_tests $machine_to_build $board_to_build
@@ -974,6 +974,8 @@ run_backend_integration_tests() {
                 "" \
                 "backend_integration_${INTEGRATION_REV}"
         fi
+
+        docker ps -q | xargs -r docker rm -v -f
 
         if [ "$testing_status" -ne 0 ]; then
             exit $testing_status

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -955,7 +955,11 @@ run_backend_integration_tests() {
             "backend_integration_${INTEGRATION_REV}"
 
         local testing_status=0
-        cd $WORKSPACE/integration/backend-tests && PYTEST_ARGS="-k 'not Multitenant'" ./run || testing_status=$?
+
+        cd $WORKSPACE/integration/backend-tests && \
+           PYTEST_ARGS="-k 'not Multitenant'" ./run && \
+           PYTEST_ARGS="-k Multitenant" ./run -f=../docker-compose.tenant.yml -f=../docker-compose.mt.yml -f=../docker-compose.storage.minio.yml || \
+           testing_status=$?
 
         if [ $testing_status -ne 0 ]; then
             github_pull_request_status \

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -628,9 +628,12 @@ build_and_test() {
 
     if [ "$machine_to_build" = "mender_servers" ]; then
         run_backend_integration_tests && \
+        sudo journalctl -u docker.service
         run_integration_tests
+        sudo journalctl -u docker.service
     else
         run_integration_tests $machine_to_build $board_to_build
+        sudo journalctl -u docker.service
     fi
 }
 

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -960,7 +960,6 @@ run_backend_integration_tests() {
         local testing_status=0
 
         cd $WORKSPACE/integration/backend-tests && \
-           PYTEST_ARGS="-k 'not Multitenant'" ./run && \
            PYTEST_ARGS="-k Multitenant" ./run -f=../docker-compose.tenant.yml -f=../docker-compose.mt.yml -f=../docker-compose.storage.minio.yml || \
            testing_status=$?
 


### PR DESCRIPTION
ideally, we'd want to run ST vs MT tests selectively:
- most services run both ST and MT tests
- MT-specific services (currently - just `tenantadm`) run only MT tests

however, to have this distinction we'd have to modify the jenkins job to accept extra args, like `RUN_BACKEND_ST`, `RUN_BACKEND_MT`. 

therefore, to avoid the fuss I propose running ST/MT tests back-to-back unconditionally. we can introduce the extra args later as an optimization. this change simply chains MT tests execution to exisiting ST tests.

https://mender-jenkins.mender.io/job/mender-builder/label=googlecloud%20&&%20mender_servers/1718/console

---
INTEGRATION NOTE: all tests with parallelism factors >1 fail stubbornly. they pass on a local machine, so no way to reproduce.
we *do* get a passing build with *sequential* tests though:
https://mender-jenkins.mender.io/job/mender-builder/1725/.

I suspect resource contention and/or temporary cloud provided problems, after looking into it for a couple days no other causes can be found. logs are both difficult to analyze and too sparse. for the record, the issue is that:
- artifact upload fails with a 500 probably (status code not displayed by pytest for some reason)
- this happens in the context of `TestFaultTolerance::test_update_image_breaks_networking`
- we do see that, within this test, services are randomly restarted may times; this should not happen, it should be 1 docker setup per test function

so, for unknown reasons, services fold and restart randomly. the test fails because either `deployments` is restarting, or minio/storage-proxy is down.

@kacf any ideas what we should do? just merge (because the PR *is* correct), or keep debugging (how?). 
