### PR TITLE
Don't list specific pytest version as dependency, but install latest

### DIFF
--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -39,7 +39,7 @@ npm install mocha selenium-webdriver@3.0.0-beta-2 saucelabs
 # Python 2 pip
 apt_get -qy --force-yes install python-pip
 pip2 install requests --upgrade
-pip2 install pytest==3.2.5
+pip2 install pytest --upgrade
 pip2 install filelock --upgrade
 pip2 install pytest-xdist --upgrade
 pip2 install pytest-html --upgrade


### PR DESCRIPTION
This is actually a no-op, since the pytest-xdist line a couple of
lines below would install latest anyway. So just make this change so
that it's more clear.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>