### PR TITLE
Move SSH enabling into mender-qa.

### DIFF
--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -8,6 +8,10 @@ cd $HOME
 # apt_get -qy update
 # apt_get -qy --force-yes install default-jre-headless
 
+# Reenable SSH that was disabled in the user-data.sh script of the build host.
+systemctl enable ssh
+systemctl start ssh
+
 curl -L https://github.com/docker/compose/releases/download/1.20.1/docker-compose-`uname -s`-`uname -m` > docker-compose
 
 cp docker-compose /usr/bin/docker-compose


### PR DESCRIPTION
This was originally in the init-script stored on Google Cloud.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>