### PR TITLE
install exact version (5.0.0) of the more-itertools package

### DIFF
--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -54,8 +54,9 @@ npm install mocha selenium-webdriver@3.0.0-beta-2 saucelabs
 
 # Python 2 pip
 apt_get -qy --force-yes install python-pip
+pip2 install more-itertools==5.0.0
 pip2 install requests --upgrade
-pip2 install pytest --upgrade
+pip2 install pytest --upgrade --upgrade-strategy=only-if-needed
 pip2 install filelock --upgrade
 pip2 install pytest-xdist --upgrade
 pip2 install pytest-html --upgrade


### PR DESCRIPTION
not sure if this will help
I can't see requirements.txt file for the integration tests (I see one only for client acceptance tests)