### PR TITLE
Upload Linux/Mac/Windows binaries of mender-artifact to S3

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -428,6 +428,7 @@ export GOPATH="$WORKSPACE/go"
 (
     cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact
     make install
+    make build-natives-contained
 )
 # Build fake client
 (
@@ -862,8 +863,10 @@ publish_artifacts() {
         local client_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender --in-integration-version HEAD)
         local mender_artifact_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-artifact --in-integration-version HEAD)
 
-        s3cmd --cf-invalidate -F put $WORKSPACE/go/bin/mender-artifact s3://mender/mender-artifact/${mender_artifact_version}/
-        s3cmd setacl s3://mender/mender-artifact/${mender_artifact_version}/mender-artifact --acl-public
+        for bin in mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe; do
+            s3cmd --cf-invalidate -F put $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact/$bin s3://mender/mender-artifact/${mender_artifact_version}/
+            s3cmd setacl s3://mender/mender-artifact/${mender_artifact_version}/$bin --acl-public
+        done
 
         cd $WORKSPACE/$board_name/
         s3cmd -F put $image_name-$device_type.ext4 s3://mender/temp_${client_version}/$image_name-$device_type.ext4


### PR DESCRIPTION
Build the binaries using the build-natives-contained make target, and
then upload the three of them to the S3 bucket

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>