### PR TITLE
QA-72: Compatible changes in the script between Jenkins and GitLab

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -353,6 +353,7 @@ build_custom_qemu() {
     # installing from source doesn't exhibit this behaviour
 
     if [ ! -f /var/tmp/qemu-built ]; then
+        rm -rf qemu
         git clone -b qemu-system-reset-race-fix \
             https://github.com/mendersoftware/qemu.git
         cd qemu

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -111,7 +111,18 @@ github_pull_request_status() {
         set +x
 
         TEST_TRACKER[$4]=$1
-        local request_body=$(cat <<EOF
+        if [ -z "$JENKINS_URL" ]; then
+            local request_body=$(cat <<EOF
+    {
+      "state": "$1",
+      "description": "$2",
+      "target_url": "$CI_JOB_URL",
+      "context": "GitLab_$4"
+    }
+EOF
+            )
+        else
+            local request_body=$(cat <<EOF
     {
       "state": "$1",
       "description": "$2",
@@ -119,7 +130,8 @@ github_pull_request_status() {
       "context": "$4"
     }
 EOF
-        )
+            )
+        fi
 
         # Split on newlines
         local IFS='
@@ -169,6 +181,7 @@ EOF
 }
 
 s3cmd_put() {
+    if [ -z "$JENKINS_URL" ]; then return; fi
     local local_path=$1
     local remote_url=$2
     shift 2
@@ -177,6 +190,7 @@ s3cmd_put() {
 }
 
 s3cmd_put_public() {
+    if [ -z "$JENKINS_URL" ]; then return; fi
     s3cmd_put $@
     local remote_url=$2
     s3cmd setacl $remote_url --acl-public

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -475,7 +475,11 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
         case "$build" in
             deployments|deviceadm|deviceauth|inventory|tenantadm|useradm)
                 cd go/src/github.com/mendersoftware/$build
-                CGO_ENABLED=0 go build
+                # Versions before 2.0.0 used "go build", later ones
+                # build everything inside multi-stage docker builds.
+                if ! grep "COPY --from=build" Dockerfile; then
+                    CGO_ENABLED=0 go build
+                fi
                 docker build -t mendersoftware/$build:pr .
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $build --version pr
                 ;;


### PR DESCRIPTION
These changes shall not disturb the regular running of tests in Jenkins, while allowing the reuse of the script from GitLab with minor tweaks.

Specifically, GitLab runs will be prevented from reporting to GitHub PRs or updating artifacts to S3. The idea behind it is not to disturb development or releases during the trial period.

I haven't tested the s3cmd refactoring, so please @kacf have a careful look.