### PR TITLE
First version for the full Mender QA pipeline for GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,37 +1,598 @@
-image: docker:git
+
+variables:
+  MENDER_REV: "master"
+  META_MENDER_REV: "master"
+  POKY_REV: "thud"
+  MENDER_QA_REV: "master"
+  MENDER_ARTIFACT_REV: "master"
+  MENDER_CONDUCTOR_REV: "master"
+  MENDER_CONDUCTOR_ENTERPRISE_REV: "master"
+  DEPLOYMENTS_REV: "master"
+  DEVICEADM_REV: "master"
+  DEVICEAUTH_REV: "master"
+  GUI_REV: "master"
+  INVENTORY_REV: "master"
+  USERADM_REV: "master"
+  MENDER_API_GATEWAY_DOCKER_REV: "master"
+  MENDER_CLI_REV: "master"
+  INTEGRATION_REV: "master"
+  TENANTADM_REV: "master"
+  MENDER_STRESS_TEST_CLIENT_REV: "master"
+  META_OPENEMBEDDED_REV: "thud"
+  META_RASPBERRYPI_REV: "thud"
+  MENDER_IMAGE_TESTS_REV: "master"
+  BASE_BRANCH: "master"
+  BUILD_QEMUX86_64_UEFI_GRUB: "true"
+  TEST_QEMUX86_64_UEFI_GRUB: "true"
+  BUILD_QEMUX86_64_BIOS_GRUB: "true"
+  TEST_QEMUX86_64_BIOS_GRUB: "true"
+  BUILD_QEMUX86_64_BIOS_GRUB_GPT: "true"
+  TEST_QEMUX86_64_BIOS_GRUB_GPT: "true"
+  BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB: "true"
+  TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB: "true"
+  BUILD_VEXPRESS_QEMU: "true"
+  TEST_VEXPRESS_QEMU: "true"
+  BUILD_VEXPRESS_QEMU_FLASH: "true"
+  TEST_VEXPRESS_QEMU_FLASH: "true"
+  BUILD_BEAGLEBONEBLACK: "true"
+  TEST_BEAGLEBONEBLACK: "false"
+  BUILD_RASPBERRYPI3: "false"
+  TEST_RASPBERRYPI3: "false"
+  RUN_INTEGRATION_TESTS: "true"
+  SPECIFIC_INTEGRATION_TEST: ""
+  TESTS_IN_PARALLEL: "8"
+  XDIST_PARALLEL_ARG: "8" #TODO: Unify these two parameters
+  PUBLISH_ARTIFACTS: ""
+  STOP_SLAVE: ""
+  CLEAN_BUILD_CACHE: ""
 
 stages:
+  - init
   - build
+  - test
 
-echo-params:
-  stage: build
+init_workspace:
+  stage: init
+  image: alpine:latest
+  tags:
+    - mender-qa-slave
   script:
-    - echo "Build parameters:"
-    - echo "DEPLOYMENTS_REV=${DEPLOYMENTS_REV}"
-    - echo "DEVICEAUTH_REV=${DEVICEAUTH_REV}"
-    - echo "GUI_REV=${GUI_REV}"
-    - echo "MENDER_REV=${MENDER_REV}"
-    - echo "MENDER_API_GATEWAY_DOCKER_REV=${MENDER_API_GATEWAY_DOCKER_REV}"
-    - echo "MENDER_ARTIFACT_REV=${MENDER_ARTIFACT_REV}"
-    - echo "MENDER_CLI_REV=${MENDER_CLI_REV}"
-    - echo "MENDER_CONDUCTOR_REV=${MENDER_CONDUCTOR_REV}"
-    - echo "MENDER_CONDUCTOR_ENTERPRISE_REV=${MENDER_CONDUCTOR_ENTERPRISE_REV}"
-    - echo "USERADM_REV=${USERADM_REV}"
-    - echo "INTEGRATION_REV=${INTEGRATION_REV}"
-    - echo "BASE_BRANCH=${BASE_BRANCH}"
-    - echo "RUN_INTEGRATION_TESTS=${RUN_INTEGRATION_TESTS}"
-    - echo "INVENTORY_REV=${INVENTORY_REV}"
-    - echo "BUILD_QEMUX86_64_UEFI_GRUB=${BUILD_QEMUX86_64_UEFI_GRUB}"
-    - echo "TEST_QEMUX86_64_UEFI_GRUB=${TEST_QEMUX86_64_UEFI_GRUB}"
-    - echo "BUILD_QEMUX86_64_BIOS_GRUB=${BUILD_QEMUX86_64_BIOS_GRUB}"
-    - echo "TEST_QEMUX86_64_BIOS_GRUB=${TEST_QEMUX86_64_BIOS_GRUB}"
-    - echo "BUILD_QEMUX86_64_BIOS_GRUB_GPT=${BUILD_QEMUX86_64_BIOS_GRUB_GPT}"
-    - echo "TEST_QEMUX86_64_BIOS_GRUB_GPT=${TEST_QEMUX86_64_BIOS_GRUB_GPT}"
-    - echo "BUILD_VEXPRESS_QEMU=${BUILD_VEXPRESS_QEMU}"
-    - echo "TEST_VEXPRESS_QEMU=${TEST_VEXPRESS_QEMU}"
-    - echo "BUILD_VEXPRESS_QEMU_FLASH=${BUILD_VEXPRESS_QEMU_FLASH}"
-    - echo "TEST_VEXPRESS_QEMU_FLASH=${TEST_VEXPRESS_QEMU_FLASH}"
-    - echo "BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB=${BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB}"
-    - echo "TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB=${TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB}"
-    - echo "BUILD_BEAGLEBONEBLACK=${BUILD_BEAGLEBONEBLACK}"
+    - export WORKSPACE=${CI_PROJECT_DIR}/..
+    - apk --update --no-cache add git openssh
+    # Prepare SSH keys
+    - eval $(ssh-agent -s)
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan github.com >> ~/.ssh/known_hosts
+    # Clone all repos in WORKSPACE
+    - cd ${WORKSPACE}
+    - git init . && git remote add origin https://github.com/mendersoftware/poky || true
+    - git fetch && git checkout -f origin/${POKY_REV}
+    - echo POKY_REV_GIT_SHA=$(git rev-parse HEAD) > ${CI_PROJECT_DIR}/build_revisions.env
+    - git clone https://github.com/mendersoftware/meta-mender || true
+    - (cd meta-mender && git fetch -u -f origin ${META_MENDER_REV}:pr && git checkout pr)
+    - (cd meta-mender && echo META_MENDER_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender || true
+    - (cd go/src/github.com/mendersoftware/mender && git fetch -u -f origin ${MENDER_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender && echo MENDER_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/integration || true
+    - (cd integration && git fetch -u -f origin ${INTEGRATION_REV}:pr && git checkout pr)
+    - (cd integration && echo INTEGRATION_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments || true
+    - (cd go/src/github.com/mendersoftware/deployments && git fetch -u -f origin ${DEPLOYMENTS_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/deployments && echo DEPLOYMENTS_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/deviceadm go/src/github.com/mendersoftware/deviceadm || true
+    - (cd go/src/github.com/mendersoftware/deviceadm && git fetch -u -f origin ${DEVICEADM_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/deviceadm && echo DEVICEADM_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/deviceauth go/src/github.com/mendersoftware/deviceauth || true
+    - (cd go/src/github.com/mendersoftware/deviceauth && git fetch -u -f origin ${DEVICEAUTH_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/deviceauth && echo DEVICEAUTH_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/gui || true
+    - (cd gui && git fetch -u -f origin ${GUI_REV}:pr && git checkout pr)
+    - (cd gui && echo GUI_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory || true
+    - (cd go/src/github.com/mendersoftware/inventory && git fetch -u -f origin ${INVENTORY_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/inventory && echo INVENTORY_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm || true
+    - (cd go/src/github.com/mendersoftware/useradm && git fetch -u -f origin ${USERADM_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/useradm && echo USERADM_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender-api-gateway-docker || true
+    - (cd mender-api-gateway-docker && git fetch -u -f origin ${MENDER_API_GATEWAY_DOCKER_REV}:pr && git checkout pr)
+    - (cd mender-api-gateway-docker && echo MENDER_API_GATEWAY_DOCKER_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client || true
+    - (cd go/src/github.com/mendersoftware/mender-stress-test-client && git fetch -u -f origin ${MENDER_STRESS_TEST_CLIENT_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender-stress-test-client && echo MENDER_STRESS_TEST_CLIENT_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender-artifact go/src/github.com/mendersoftware/mender-artifact || true
+    - (cd go/src/github.com/mendersoftware/mender-artifact && git fetch -u -f origin ${MENDER_ARTIFACT_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender-artifact && echo MENDER_ARTIFACT_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git@github.com:mendersoftware/tenantadm go/src/github.com/mendersoftware/tenantadm || true
+    - (cd go/src/github.com/mendersoftware/tenantadm && git fetch -u -f origin ${TENANTADM_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/tenantadm && echo TENANTADM_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mem/oe-meta-go.git || true
+    - (cd oe-meta-go && git checkout -f master)
+    - git clone git://git.openembedded.org/meta-openembedded.git || true
+    - (cd meta-openembedded && git fetch -u -f origin ${META_OPENEMBEDDED_REV}:pr && git checkout pr)
+    - (cd meta-openembedded && echo META_OPENEMBEDDED_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git://github.com/agherzan/meta-raspberrypi.git || true
+    - (cd meta-raspberrypi && git fetch -u -f origin ${META_RASPBERRYPI_REV}:pr && git checkout pr)
+    - (cd meta-raspberrypi && echo META_RASPBERRYPI_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git://github.com/mendersoftware/mender-conductor.git go/src/github.com/mendersoftware/mender-conductor || true
+    - (cd go/src/github.com/mendersoftware/mender-conductor && git fetch -u -f origin ${MENDER_CONDUCTOR_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender-conductor && echo MENDER_CONDUCTOR_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git@github.com:mendersoftware/mender-conductor-enterprise.git go/src/github.com/mendersoftware/mender-conductor-enterprise || true
+    - (cd go/src/github.com/mendersoftware/mender-conductor-enterprise && git fetch -u -f origin ${MENDER_CONDUCTOR_ENTERPRISE_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender-conductor-enterprise && echo MENDER_CONDUCTOR_ENTERPRISE_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender-cli.git go/src/github.com/mendersoftware/mender-cli || true
+    - (cd go/src/github.com/mendersoftware/mender-cli && git fetch -u -f origin ${MENDER_CLI_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/mender-cli && echo MENDER_CLI_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone https://github.com/mendersoftware/mender-image-tests || true
+    - (cd mender-image-tests && git fetch -u -f origin ${MENDER_IMAGE_TESTS_REV}:pr && git checkout pr)
+    - (cd mender-image-tests && echo MENDER_IMAGE_TESTS_REV_GIT_SHA=$(git rev-parse HEAD) >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - cat ${CI_PROJECT_DIR}/build_revisions.env
+    - tar -czf /tmp/workspace.tar.gz .
+    - mv /tmp/workspace.tar.gz ${CI_PROJECT_DIR}/workspace.tar.gz
+  artifacts:
+    expire_in: 2w
+    paths:
+      - workspace.tar.gz
+      - build_revisions.env
 
+.template_build_test_acc: &build_and_test_acceptance
+  image: teracy/ubuntu:16.04-dind-latest
+  services:
+  - docker:dind
+  tags:
+    - mender-qa-slave
+  before_script:
+    - export WORKSPACE=${CI_PROJECT_DIR}/..
+    - export GOPATH="$WORKSPACE/go"
+    # This template is used in both build and acc test stages
+    - test -n "$ONLY_BUILD" && export TEST_QEMUX86_64_UEFI_GRUB=false
+    - test -n "$ONLY_BUILD" && export TEST_VEXPRESS_QEMU=false
+    - export RUN_INTEGRATION_TESTS=false
+    # Prepare tzdata unatended configuration
+    - ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
+    # basic tools
+    - apt-get update -q
+    - apt-get install -qqy
+      git wget gnupg2 pass autoconf automake build-essential diffstat gawk chrpath
+      libsdl1.2-dev e2tools nfs-client s3cmd psmisc screen libssl-dev python-dev
+      libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo pkg-config
+      zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev
+      libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler
+      qemu-system-x86 bc kpartx liblzma-dev cpio sudo
+    # Prepare mender user
+    - useradd -m -u 1010 mender || true
+    - mkdir -p /home/mender/.ssh
+    - echo "mender ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+    - sed -i -e 's/^\( *Defaults *requiretty *\)$/# \1/' /etc/sudoers
+    - chown -R mender:mender /home/mender
+    - chown -R mender:mender ${WORKSPACE}
+    - usermod -a -G docker mender
+    # docker-compose from upstream
+    - curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+    - chmod +x /usr/local/bin/docker-compose
+    # golang from upstream
+    - wget -q https://storage.googleapis.com/golang/go1.12.linux-amd64.tar.gz
+    - gunzip -c go1.12.linux-amd64.tar.gz | (cd /usr/local && tar x)
+    - ln -sf /usr/local/go/bin/go /usr/local/bin/go
+    - ln -sf /usr/local/go/bin/godoc /usr/local/bin/godoc
+    - ln -sf /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+    # Python 2 pip
+    - apt-get install -qqy python-pip
+    - pip install --upgrade pip
+    - pip2 install requests --upgrade
+    - pip2 install pytest --upgrade
+    - pip2 install filelock --upgrade
+    - pip2 install pytest-xdist --upgrade
+    - pip2 install pytest-html --upgrade
+    - pip2 install -I fabric==1.14.0
+    - pip2 install psutil --upgrade
+    - pip2 install boto3 --upgrade
+    - pip2 install pycrypto --upgrade
+    # Python 3 pip
+    - apt-get install -qqy python3-pip
+    - pip3 install --upgrade pyyaml
+    # Locales
+    - apt-get install locales
+    - locale-gen --purge en_US.UTF-8
+    - export LC_ALL=en_US.UTF-8
+    - export LANG=en_US.UTF-8
+    - export LANGUAGE=en_US.UTF-8
+    # debugfs
+    - cp /sbin/debugfs /usr/bin/ || echo "debugfs not in /sbin/"
+    # sysstat monitoring suite
+    # collect cpu, load avg, memory and io usage every 2 secs forever
+    # use 'sar' from sysstat to render the result file (~/sysstat.log) manually
+    - apt-get install -qqy sysstat
+    - sed -i 's/false/true/g' /etc/default/sysstat
+    - service sysstat start
+    - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
+  script:
+    - mv workspace.tar.gz /tmp
+    - cd ${WORKSPACE}
+    - rm -rf *
+    - tar -xf /tmp/workspace.tar.gz
+    - source ${CI_PROJECT_DIR}/build_revisions.env
+    - export $(cat ${CI_PROJECT_DIR}/build_revisions.env | cut -d= -f1)
+    - chown -R mender:mender ${WORKSPACE}
+    - export HOME="/home/mender"
+    - sudo -E -u mender ${WORKSPACE}/mender-qa/scripts/jenkins-yoctobuild-build.sh
+
+build_qemux86_64_uefi_grub:
+  stage: build
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_qemux86_64_uefi_grub
+    ONLY_BUILD: "true"
+  only:
+    variables:
+      - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
+  after_script:
+    - docker save mendersoftware/mender-client-qemu:pr -o mender-client-qemu_qemux86_64_uefi_grub.tar
+    - cp ${CI_PROJECT_DIR}/../build-qemux86-64-uefi-grub/tmp/deploy/images/qemux86-64/core-image-full-cmdline-qemux86-64.ext4 .
+  artifacts:
+    expire_in: 2w
+    paths:
+      - mender-client-qemu_qemux86_64_uefi_grub.tar
+      - core-image-full-cmdline-qemux86-64.ext4
+
+build_vexpress_qemu:
+  stage: build
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_vexpress_qemu
+    ONLY_BUILD: "true"
+  only:
+    variables:
+      - $BUILD_VEXPRESS_QEMU == "true"
+  after_script:
+    - docker save mendersoftware/mender-client-qemu:pr -o mender-client-qemu_vexpress_qemu.tar
+    - cp ${CI_PROJECT_DIR}/../build-vexpress-qemu/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.ext4 .
+  artifacts:
+    expire_in: 2w
+    paths:
+      - mender-client-qemu_vexpress_qemu.tar
+      - core-image-full-cmdline-vexpress-qemu.ext4
+
+build_servers:
+  stage: build
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_servers
+    ONLY_BUILD: "true"
+  after_script:
+    - docker save mendersoftware/deployments:pr -o deployments.tar
+    - docker save mendersoftware/deviceadm:pr -o deviceadm.tar
+    - docker save mendersoftware/deviceauth:pr -o deviceauth.tar
+    - docker save mendersoftware/gui:pr -o gui.tar
+    - docker save mendersoftware/inventory:pr -o inventory.tar
+    - docker save mendersoftware/api-gateway:pr -o api-gateway.tar
+    - docker save mendersoftware/mender-conductor:pr -o mender-conductor.tar
+    - docker save mendersoftware/mender-conductor-enterprise:pr -o mender-conductor-enterprise.tar
+    - docker save mendersoftware/tenantadm:pr -o tenantadm.tar
+    - docker save mendersoftware/useradm:pr -o useradm.tar
+    - docker save mendersoftware/email-sender:pr -o email-sender.tar
+    - docker save mendersoftware/mender-client-docker:pr -o mender-client-docker.tar
+    # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
+    - tar -cf host-tools.tar -C ../go/bin/ .
+
+  artifacts:
+    expire_in: 2w
+    paths:
+      - deployments.tar
+      - deviceadm.tar
+      - deviceauth.tar
+      - gui.tar
+      - inventory.tar
+      - api-gateway.tar
+      - mender-conductor.tar
+      - mender-conductor-enterprise.tar
+      - tenantadm.tar
+      - useradm.tar
+      - email-sender.tar
+      - mender-client-docker.tar
+      - host-tools.tar
+
+test_qemux86_64_uefi_grub:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_qemux86_64_uefi_grub
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_qemux86_64_uefi_grub.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_qemux86_64_uefi_grub.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_qemux86_64_uefi_grub.xml
+      - report_qemux86_64_uefi_grub.html
+    reports:
+      junit: results_qemux86_64_uefi_grub.xml
+  only:
+    # The build for this configuration is done unconditionally in build_qemux86_64_uefi_grub job,
+    # so run corresponding test job only if TEST_QEMUX86_64_UEFI_GRUB is set
+    variables:
+      - $TEST_QEMUX86_64_UEFI_GRUB == "true"
+
+test_vexpress_qemu:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_vexpress_qemu
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_vexpress_qemu.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_vexpress_qemu.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_vexpress_qemu.xml
+      - report_vexpress_qemu.html
+    reports:
+      junit: results_vexpress_qemu.xml
+  only:
+    # The build for this configuration is done unconditionally in build_vexpress_qemu job,
+    # so run corresponding test job only if TEST_VEXPRESS_QEMU is set
+    variables:
+      - $TEST_VEXPRESS_QEMU == "true"
+
+test_qemux86_64_bios_grub:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_qemux86_64_bios_grub
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_qemux86_64_bios_grub.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_qemux86_64_bios_grub.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_qemux86_64_bios_grub.xml
+      - report_qemux86_64_bios_grub.html
+    reports:
+      junit: results_qemux86_64_bios_grub.xml
+  only:
+    variables:
+      - $BUILD_QEMUX86_64_BIOS_GRUB == "true"
+      - $TEST_QEMUX86_64_BIOS_GRUB == "true"
+
+test_qemux86_64_bios_grub_gpt:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_qemux86_64_bios_grub_gpt.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_qemux86_64_bios_grub_gpt.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_qemux86_64_bios_grub_gpt.xml
+      - report_qemux86_64_bios_grub_gpt.html
+    reports:
+      junit: results_qemux86_64_bios_grub_gpt.xml
+  only:
+    variables:
+      - $BUILD_QEMUX86_64_BIOS_GRUB_GPT == "true"
+      - $TEST_QEMUX86_64_BIOS_GRUB_GPT == "true"
+
+test_vexpress_qemu_uboot_uefi_grub:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_vexpress_qemu_uboot_uefi_grub.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_vexpress_qemu_uboot_uefi_grub.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_vexpress_qemu_uboot_uefi_grub.xml
+      - report_vexpress_qemu_uboot_uefi_grub.html
+    reports:
+      junit: results_vexpress_qemu_uboot_uefi_grub.xml
+  only:
+    variables:
+      - $BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
+      - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
+
+test_vexpress_qemu_flash:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_vexpress_qemu_flash
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_vexpress_qemu_flash.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_vexpress_qemu_flash.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_vexpress_qemu_flash.xml
+      - report_vexpress_qemu_flash.html
+    reports:
+      junit: results_vexpress_qemu_flash.xml
+  only:
+    variables:
+      - $BUILD_VEXPRESS_QEMU_FLASH == "true"
+      - $TEST_VEXPRESS_QEMU_FLASH == "true"
+
+test_beagleboneblack:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_beagleboneblack
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_beagleboneblack.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_beagleboneblack.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_beagleboneblack.xml
+      - report_beagleboneblack.html
+    reports:
+      junit: results_beagleboneblack.xml
+  only:
+    variables:
+      - $BUILD_BEAGLEBONEBLACK == "true"
+      - $TEST_BEAGLEBONEBLACK == "true"
+
+test_raspberrypi3:
+  stage: test
+  dependencies:
+    - init_workspace
+  <<: *build_and_test_acceptance
+  variables:
+    JOB_BASE_NAME: mender_raspberrypi3
+  after_script:
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_raspberrypi3.xml
+    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_raspberrypi3.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_raspberrypi3.xml
+      - report_raspberrypi3.html
+    reports:
+      junit: results_raspberrypi3.xml
+  only:
+    variables:
+      - $BUILD_RASPBERRYPI3 == "true"
+      - $TEST_RASPBERRYPI3 == "true"
+
+.template_test_integ: &test_integration
+  image: docker:dind
+  tags:
+    - mender-qa-slave
+  before_script:
+    - /usr/local/bin/dockerd-entrypoint.sh &
+    - sleep 1
+    - docker version
+    - apk --update --no-cache add bash curl git openssh device-mapper py-pip
+      iptables gcc python2-dev libffi-dev libc-dev openssl-dev make python3
+      python3-dev e2fsprogs-extra openssl
+    # mender-artifact and other GO tools not build for muslc will throw "not found" error
+    # see https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
+    - mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
+    - pip install docker-compose==1.24.0
+    - pip3 install pyyaml
+    - rm -rf /var/cache/apk/*
+    - git clone https://github.com/mendersoftware/integration || true
+    - (cd integration && git fetch -u -f origin ${INTEGRATION_REV}:pr && git checkout pr)
+    - pip install pycrypto && pip install -r integration/tests/requirements.txt
+    - pip install pytest-xdist --upgrade
+    - pip install pytest-html --upgrade
+    # Load all docker images
+    - docker load -i deployments.tar
+    - docker load -i deviceadm.tar
+    - docker load -i deviceauth.tar
+    - docker load -i gui.tar
+    - docker load -i inventory.tar
+    - docker load -i api-gateway.tar
+    - docker load -i mender-conductor.tar
+    - docker load -i mender-conductor-enterprise.tar
+    - docker load -i tenantadm.tar
+    - docker load -i useradm.tar
+    - docker load -i email-sender.tar
+    - docker load -i mender-client-docker.tar
+    - docker load -i mender-client-qemu_qemux86_64_uefi_grub.tar ||
+      docker load -i mender-client-qemu_vexpress_qemu.tar
+    # Login for private repos
+    - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+    # Set testing versions to PR
+    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+      integration/extra/release_tool.py --set-version-of $repo --version pr;
+      done
+    # Other dependencies
+    - mv core-image-full-cmdline-qemux86-64.ext4 integration/tests ||
+      mv core-image-full-cmdline-vexpress-qemu.ext4 integration/tests
+    - tar -xf host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/
+    - tar -xf host-tools.tar ./mender-stress-test-client && mv mender-stress-test-client /usr/local/bin/
+    - tar -xf host-tools.tar ./directory-artifact-gen && mv directory-artifact-gen /usr/local/bin/
+  script:
+    - source ${CI_PROJECT_DIR}/build_revisions.env
+    - export $(cat ${CI_PROJECT_DIR}/build_revisions.env | cut -d= -f1)
+    - cd integration/tests
+    - ./run.sh --no-download --machine-name $MACHINE_NAME
+
+test_integration_qemux86_64_uefi_grub:
+  stage: test
+  <<: *test_integration
+  dependencies:
+    - init_workspace
+    - build_servers
+    - build_qemux86_64_uefi_grub
+  variables:
+    MACHINE_NAME: qemux86-64
+  after_script:
+    - cp ${CI_PROJECT_DIR}/integration/tests/results.xml results_qemux86_64_uefi_grub.xml
+    - cp ${CI_PROJECT_DIR}/integration/tests/report.html report_qemux86_64_uefi_grub.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_qemux86_64_uefi_grub.xml
+      - report_qemux86_64_uefi_grub.html
+    reports:
+      junit: results_qemux86_64_uefi_grub.xml
+  only:
+    # The variables expressions will work after GitLab release 12.0,
+    # see https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/27925
+    # Meanwhile split them into two different conditions as a workaround
+    variables:
+      - $RUN_INTEGRATION_TESTS == "true"
+    variables:
+      - $TEST_QEMUX86_64_UEFI_GRUB == "true"
+
+test_integration_vexpress_qemu:
+  stage: test
+  <<: *test_integration
+  dependencies:
+    - init_workspace
+    - build_servers
+    - build_vexpress_qemu
+  variables:
+    MACHINE_NAME: vexpress-qemu
+  after_script:
+    - cp ${CI_PROJECT_DIR}/integration/tests/results.xml results_vexpress_qemu.xml
+    - cp ${CI_PROJECT_DIR}/integration/tests/report.html report_vexpress_qemu.html
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - results_vexpress_qemu.xml
+      - report_vexpress_qemu.html
+    reports:
+      junit: results_vexpress_qemu.xml
+  only:
+    variables:
+      - $RUN_INTEGRATION_TESTS == "true"
+    variables:
+      - $TEST_VEXPRESS_QEMU == "true"

--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -68,7 +68,7 @@ pip3 install pyyaml --upgrade
 
 # sysstat monitoring suite
 # collect cpu, load avg, memory and io usage every 2 secs forever
-# use 'sadf' from sysstat to render the result file (~/sysstat.log) manually
+# use sar from sysstat to render the result file (~/sysstat.log) manually
 apt_get -qy --force-yes install sysstat
 sudo sed -i 's/false/true/g' /etc/default/sysstat
 sudo service sysstat start 


### PR DESCRIPTION
This commit introduces the first production version of the Mender QA
pipeline for GitLab CI.

Basically, what Jenkins runs through jenkins-yoctobuild-init-script.sh
has been ported to before_script on GitLab pipeline; while the clone of
all microservices that is specified for Jenkins in its configuration, is
done in the main script of GitLab pipeline.

Functionality wise, it reassembles Jenkins builds with the following
exceptions:
* Integration tests are run in parallel with acceptance tests
* There is no support for integration tests with precompiled client
* Upload of artifacts to S3 and Docker pushes (and therefore releases)
are not supported. This is a temporary workaround to not dirturbe the
development process.

The runs are slower than Jenkins due to missing optimizations:
* QA-79: KVM acceleration for qemu emulation
* QA-80: NFS mount for yocto builds

Implementaion detail. Three different Docker images are in use by the
differnt jobs:
* Init stage uses a simple Alpine Linux image
* Build and acceptance tests jobs use a Ubuntu based image, with Docker
as a service (DinD) to build the Docker images of the microservices. A
Linux user is created to run bitbake as non root.
* Integration tests jobs use a privilaged official DinD image to allow
composition of containers and their shared directories as the tests
require.

Changelog: Title

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>