### PR TITLE
Add jq dependency for the integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -497,7 +497,7 @@ test_raspberrypi3:
     - docker version
     - apk --update --no-cache add bash curl git openssh device-mapper py-pip
       iptables gcc python2-dev libffi-dev libc-dev openssl-dev make python3
-      python3-dev e2fsprogs-extra openssl
+      python3-dev e2fsprogs-extra openssl jq
     # mender-artifact and other GO tools not build for muslc will throw "not found" error
     # see https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker
     - mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
The missing dependendy is the reason for Demo Artifact tests to fail in
GitLab while passing in Jenkins

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>