### PR TITLE
Use Docker 18.x for integration tests and export socket variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -494,12 +494,13 @@ test_raspberrypi3:
       - $TEST_RASPBERRYPI3 == "true"
 
 .template_test_integ: &test_integration
-  image: docker:dind
+  image: docker:18-dind
   tags:
     - mender-qa-slave
   before_script:
     - /usr/local/bin/dockerd-entrypoint.sh &
     - sleep 10
+    - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
     - apk --update --no-cache add bash curl git openssh device-mapper py-pip
       iptables gcc python2-dev libffi-dev libc-dev openssl-dev make python3


### PR DESCRIPTION
For consistency, let's use the same version of Docker in build + acc
tests than in integ tests.

Also, it seems like the Docker client fails to resolve the correct port
for Docker daemon, so export the socket variable directly.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>