### PR TITLE
Fixes to build enterprise components in GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,11 +8,13 @@ variables:
   MENDER_CONDUCTOR_REV: "master"
   MENDER_CONDUCTOR_ENTERPRISE_REV: "master"
   DEPLOYMENTS_REV: "master"
+  DEPLOYMENTS_ENTERPRISE_REV: "master"
   DEVICEADM_REV: "master"
   DEVICEAUTH_REV: "master"
   GUI_REV: "master"
   INVENTORY_REV: "master"
   USERADM_REV: "master"
+  USERADM_ENTERPRISE_REV: "master"
   MENDER_API_GATEWAY_DOCKER_REV: "master"
   MENDER_CLI_REV: "master"
   INTEGRATION_REV: "master"
@@ -82,6 +84,9 @@ init_workspace:
     - git clone https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments || true
     - (cd go/src/github.com/mendersoftware/deployments && git fetch -u -f origin ${DEPLOYMENTS_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deployments && echo -e "DEPLOYMENTS_REV=$DEPLOYMENTS_REV\nDEPLOYMENTS_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git@github.com:mendersoftware/deployments-enterprise go/src/github.com/mendersoftware/deployments-enterprise || true
+    - (cd go/src/github.com/mendersoftware/deployments-enterprise && git fetch -u -f origin ${DEPLOYMENTS_ENTERPRISE_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/deployments-enterprise && echo -e "DEPLOYMENTS_ENTERPRISE_REV=$DEPLOYMENTS_ENTERPRISE_REV\nDEPLOYMENTS_ENTERPRISE_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
     - git clone https://github.com/mendersoftware/deviceadm go/src/github.com/mendersoftware/deviceadm || true
     - (cd go/src/github.com/mendersoftware/deviceadm && git fetch -u -f origin ${DEVICEADM_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deviceadm && echo -e "DEVICEADM_REV=$DEVICEADM_REV\nDEVICEADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
@@ -97,6 +102,9 @@ init_workspace:
     - git clone https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm || true
     - (cd go/src/github.com/mendersoftware/useradm && git fetch -u -f origin ${USERADM_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/useradm && echo -e "USERADM_REV=$USERADM_REV\nUSERADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
+    - git clone git@github.com:mendersoftware/useradm-enterprise go/src/github.com/mendersoftware/useradm-enterprise || true
+    - (cd go/src/github.com/mendersoftware/useradm-enterprise && git fetch -u -f origin ${USERADM_ENTERPRISE_REV}:pr && git checkout pr)
+    - (cd go/src/github.com/mendersoftware/useradm-enterprise && echo -e "USERADM_ENTERPRISE_REV=$USERADM_ENTERPRISE_REV\nUSERADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
     - git clone https://github.com/mendersoftware/mender-api-gateway-docker || true
     - (cd mender-api-gateway-docker && git fetch -u -f origin ${MENDER_API_GATEWAY_DOCKER_REV}:pr && git checkout pr)
     - (cd mender-api-gateway-docker && echo -e "MENDER_API_GATEWAY_DOCKER_REV=$MENDER_API_GATEWAY_DOCKER_REV\nMENDER_API_GATEWAY_DOCKER_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
@@ -275,36 +283,30 @@ build_servers:
     JOB_BASE_NAME: mender_servers
     ONLY_BUILD: "true"
   after_script:
-    - docker save mendersoftware/deployments:pr -o deployments.tar
-    - docker save mendersoftware/deviceadm:pr -o deviceadm.tar
-    - docker save mendersoftware/deviceauth:pr -o deviceauth.tar
-    - docker save mendersoftware/gui:pr -o gui.tar
-    - docker save mendersoftware/inventory:pr -o inventory.tar
-    - docker save mendersoftware/api-gateway:pr -o api-gateway.tar
-    - docker save mendersoftware/mender-conductor:pr -o mender-conductor.tar
-    - docker save mendersoftware/mender-conductor-enterprise:pr -o mender-conductor-enterprise.tar
-    - docker save mendersoftware/tenantadm:pr -o tenantadm.tar
-    - docker save mendersoftware/useradm:pr -o useradm.tar
-    - docker save mendersoftware/email-sender:pr -o email-sender.tar
-    - docker save mendersoftware/mender-client-docker:pr -o mender-client-docker.tar
+    - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
+      if ! echo $repo | grep -q mender-client-qemu; then
+      docker save mendersoftware/${repo}:pr -o ${repo}.tar;
+      fi; done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf host-tools.tar -C ../go/bin/ .
 
   artifacts:
     expire_in: 2w
     paths:
+      - api-gateway.tar
       - deployments.tar
+      - deployments-enterprise.tar
       - deviceadm.tar
       - deviceauth.tar
+      - email-sender.tar
       - gui.tar
       - inventory.tar
-      - api-gateway.tar
+      - mender-client-docker.tar
       - mender-conductor.tar
       - mender-conductor-enterprise.tar
       - tenantadm.tar
       - useradm.tar
-      - email-sender.tar
-      - mender-client-docker.tar
+      - useradm-enterprise.tar
       - host-tools.tar
 
 test_qemux86_64_uefi_grub:
@@ -517,22 +519,13 @@ test_raspberrypi3:
     - pip install pytest-xdist --upgrade
     - pip install pytest-html --upgrade
     # Load all docker images
-    - docker load -i deployments.tar
-    - docker load -i deviceadm.tar
-    - docker load -i deviceauth.tar
-    - docker load -i gui.tar
-    - docker load -i inventory.tar
-    - docker load -i api-gateway.tar
-    - docker load -i mender-conductor.tar
-    - docker load -i mender-conductor-enterprise.tar
-    - docker load -i tenantadm.tar
-    - docker load -i useradm.tar
-    - docker load -i email-sender.tar
-    - docker load -i mender-client-docker.tar
-    - docker load -i mender-client-qemu_qemux86_64_uefi_grub.tar ||
-      docker load -i mender-client-qemu_vexpress_qemu.tar
-    - docker load -i mender-client-qemu-rofs_qemux86_64_uefi_grub.tar ||
-      docker load -i mender-client-qemu-rofs_vexpress_qemu.tar
+    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+      if echo $repo | grep -q mender-client-qemu; then
+      docker load -i ${repo}_qemux86_64_uefi_grub.tar ||
+      docker load -i ${repo}_vexpress_qemu.tar;
+      else
+      docker load -i ${repo}.tar;
+      fi; done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     # Set testing versions to PR

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,7 +59,7 @@ init_workspace:
   tags:
     - mender-qa-slave
   script:
-    - export WORKSPACE=${CI_PROJECT_DIR}/..
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update --no-cache add git openssh
     # Prepare SSH keys
     - eval $(ssh-agent -s)
@@ -67,74 +67,79 @@ init_workspace:
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
     - ssh-keyscan github.com >> ~/.ssh/known_hosts
-    # Clone all repos in WORKSPACE
+    # Clean WORKSPACE and clone all repos
+    - find ${WORKSPACE}
+      -mindepth 1
+      -maxdepth 1
+      -not -name $(basename ${CI_PROJECT_DIR})
+      -exec rm -rf '{}' ';'
     - cd ${WORKSPACE}
-    - git init . && git remote add origin https://github.com/mendersoftware/poky || true
+    - git init . && git remote add origin https://github.com/mendersoftware/poky
     - git fetch && git checkout -f origin/${POKY_REV}
     - echo -e "POKY_REV=$POKY_REV\nPOKY_REV_GIT_SHA=$(git rev-parse HEAD)" > ${CI_PROJECT_DIR}/build_revisions.env
-    - git clone https://github.com/mendersoftware/meta-mender || true
+    - git clone https://github.com/mendersoftware/meta-mender
     - (cd meta-mender && git fetch -u -f origin ${META_MENDER_REV}:pr && git checkout pr)
     - (cd meta-mender && echo -e "META_MENDER_REV=$META_MENDER_REV\nMETA_MENDER_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender || true
+    - git clone https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender
     - (cd go/src/github.com/mendersoftware/mender && git fetch -u -f origin ${MENDER_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender && echo -e "MENDER_REV=$MENDER_REV\nMENDER_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/integration || true
+    - git clone https://github.com/mendersoftware/integration
     - (cd integration && git fetch -u -f origin ${INTEGRATION_REV}:pr && git checkout pr)
     - (cd integration && echo -e "INTEGRATION_REV=$INTEGRATION_REV\nINTEGRATION_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments || true
+    - git clone https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments
     - (cd go/src/github.com/mendersoftware/deployments && git fetch -u -f origin ${DEPLOYMENTS_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deployments && echo -e "DEPLOYMENTS_REV=$DEPLOYMENTS_REV\nDEPLOYMENTS_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git@github.com:mendersoftware/deployments-enterprise go/src/github.com/mendersoftware/deployments-enterprise || true
+    - git clone git@github.com:mendersoftware/deployments-enterprise go/src/github.com/mendersoftware/deployments-enterprise
     - (cd go/src/github.com/mendersoftware/deployments-enterprise && git fetch -u -f origin ${DEPLOYMENTS_ENTERPRISE_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deployments-enterprise && echo -e "DEPLOYMENTS_ENTERPRISE_REV=$DEPLOYMENTS_ENTERPRISE_REV\nDEPLOYMENTS_ENTERPRISE_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/deviceadm go/src/github.com/mendersoftware/deviceadm || true
+    - git clone https://github.com/mendersoftware/deviceadm go/src/github.com/mendersoftware/deviceadm
     - (cd go/src/github.com/mendersoftware/deviceadm && git fetch -u -f origin ${DEVICEADM_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deviceadm && echo -e "DEVICEADM_REV=$DEVICEADM_REV\nDEVICEADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/deviceauth go/src/github.com/mendersoftware/deviceauth || true
+    - git clone https://github.com/mendersoftware/deviceauth go/src/github.com/mendersoftware/deviceauth
     - (cd go/src/github.com/mendersoftware/deviceauth && git fetch -u -f origin ${DEVICEAUTH_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/deviceauth && echo -e "DEVICEAUTH_REV=$DEVICEAUTH_REV\nDEVICEAUTH_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/gui || true
+    - git clone https://github.com/mendersoftware/gui
     - (cd gui && git fetch -u -f origin ${GUI_REV}:pr && git checkout pr)
     - (cd gui && echo -e "GUI_REV=$GUI_REV\nGUI_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory || true
+    - git clone https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory
     - (cd go/src/github.com/mendersoftware/inventory && git fetch -u -f origin ${INVENTORY_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/inventory && echo -e "INVENTORY_REV=$INVENTORY_REV\nINVENTORY_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm || true
+    - git clone https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm
     - (cd go/src/github.com/mendersoftware/useradm && git fetch -u -f origin ${USERADM_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/useradm && echo -e "USERADM_REV=$USERADM_REV\nUSERADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git@github.com:mendersoftware/useradm-enterprise go/src/github.com/mendersoftware/useradm-enterprise || true
+    - git clone git@github.com:mendersoftware/useradm-enterprise go/src/github.com/mendersoftware/useradm-enterprise
     - (cd go/src/github.com/mendersoftware/useradm-enterprise && git fetch -u -f origin ${USERADM_ENTERPRISE_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/useradm-enterprise && echo -e "USERADM_ENTERPRISE_REV=$USERADM_ENTERPRISE_REV\nUSERADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender-api-gateway-docker || true
+    - git clone https://github.com/mendersoftware/mender-api-gateway-docker
     - (cd mender-api-gateway-docker && git fetch -u -f origin ${MENDER_API_GATEWAY_DOCKER_REV}:pr && git checkout pr)
     - (cd mender-api-gateway-docker && echo -e "MENDER_API_GATEWAY_DOCKER_REV=$MENDER_API_GATEWAY_DOCKER_REV\nMENDER_API_GATEWAY_DOCKER_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client || true
+    - git clone https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client
     - (cd go/src/github.com/mendersoftware/mender-stress-test-client && git fetch -u -f origin ${MENDER_STRESS_TEST_CLIENT_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender-stress-test-client && echo -e "MENDER_STRESS_TEST_CLIENT_REV=$MENDER_STRESS_TEST_CLIENT_REV\nMENDER_STRESS_TEST_CLIENT_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender-artifact go/src/github.com/mendersoftware/mender-artifact || true
+    - git clone https://github.com/mendersoftware/mender-artifact go/src/github.com/mendersoftware/mender-artifact
     - (cd go/src/github.com/mendersoftware/mender-artifact && git fetch -u -f origin ${MENDER_ARTIFACT_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender-artifact && echo -e "MENDER_ARTIFACT_REV=$MENDER_ARTIFACT_REV\nMENDER_ARTIFACT_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git@github.com:mendersoftware/tenantadm go/src/github.com/mendersoftware/tenantadm || true
+    - git clone git@github.com:mendersoftware/tenantadm go/src/github.com/mendersoftware/tenantadm
     - (cd go/src/github.com/mendersoftware/tenantadm && git fetch -u -f origin ${TENANTADM_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/tenantadm && echo -e "TENANTADM_REV=$TENANTADM_REV\nTENANTADM_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mem/oe-meta-go.git || true
+    - git clone https://github.com/mem/oe-meta-go.git
     - (cd oe-meta-go && git checkout -f master)
-    - git clone git://git.openembedded.org/meta-openembedded.git || true
+    - git clone git://git.openembedded.org/meta-openembedded.git
     - (cd meta-openembedded && git fetch -u -f origin ${META_OPENEMBEDDED_REV}:pr && git checkout pr)
     - (cd meta-openembedded && echo -e "META_OPENEMBEDDED_REV=$META_OPENEMBEDDED_REV\nMETA_OPENEMBEDDED_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git://github.com/agherzan/meta-raspberrypi.git || true
+    - git clone git://github.com/agherzan/meta-raspberrypi.git
     - (cd meta-raspberrypi && git fetch -u -f origin ${META_RASPBERRYPI_REV}:pr && git checkout pr)
     - (cd meta-raspberrypi && echo -e "META_RASPBERRYPI_REV=$META_RASPBERRYPI_REV\nMETA_RASPBERRYPI_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git://github.com/mendersoftware/mender-conductor.git go/src/github.com/mendersoftware/mender-conductor || true
+    - git clone git://github.com/mendersoftware/mender-conductor.git go/src/github.com/mendersoftware/mender-conductor
     - (cd go/src/github.com/mendersoftware/mender-conductor && git fetch -u -f origin ${MENDER_CONDUCTOR_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender-conductor && echo -e "MENDER_CONDUCTOR_REV=$MENDER_CONDUCTOR_REV\nMENDER_CONDUCTOR_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone git@github.com:mendersoftware/mender-conductor-enterprise.git go/src/github.com/mendersoftware/mender-conductor-enterprise || true
+    - git clone git@github.com:mendersoftware/mender-conductor-enterprise.git go/src/github.com/mendersoftware/mender-conductor-enterprise
     - (cd go/src/github.com/mendersoftware/mender-conductor-enterprise && git fetch -u -f origin ${MENDER_CONDUCTOR_ENTERPRISE_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender-conductor-enterprise && echo -e "MENDER_CONDUCTOR_ENTERPRISE_REV=$MENDER_CONDUCTOR_ENTERPRISE_REV\nMENDER_CONDUCTOR_ENTERPRISE_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender-cli.git go/src/github.com/mendersoftware/mender-cli || true
+    - git clone https://github.com/mendersoftware/mender-cli.git go/src/github.com/mendersoftware/mender-cli
     - (cd go/src/github.com/mendersoftware/mender-cli && git fetch -u -f origin ${MENDER_CLI_REV}:pr && git checkout pr)
     - (cd go/src/github.com/mendersoftware/mender-cli && echo -e "MENDER_CLI_REV=$MENDER_CLI_REV\nMENDER_CLI_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-    - git clone https://github.com/mendersoftware/mender-image-tests || true
+    - git clone https://github.com/mendersoftware/mender-image-tests
     - (cd mender-image-tests && git fetch -u -f origin ${MENDER_IMAGE_TESTS_REV}:pr && git checkout pr)
     - (cd mender-image-tests && echo -e "MENDER_IMAGE_TESTS_REV=$MENDER_IMAGE_TESTS_REV\nMENDER_IMAGE_TESTS_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
     - cat ${CI_PROJECT_DIR}/build_revisions.env
@@ -156,7 +161,7 @@ init_workspace:
     # Check correct dind setup
     - docker version
     # Export required yoctobuild script variables
-    - export WORKSPACE=${CI_PROJECT_DIR}/..
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - export GOPATH="$WORKSPACE/go"
     # This template is used in both build and acc test stages
     - test -n "$ONLY_BUILD" && export TEST_QEMUX86_64_UEFI_GRUB=false
@@ -224,8 +229,9 @@ init_workspace:
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
     - mv workspace.tar.gz /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - rm -rf *
     - tar -xf /tmp/workspace.tar.gz
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - export $(cat ${CI_PROJECT_DIR}/build_revisions.env | cut -d= -f1)

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -481,7 +481,7 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
                           || echo "deployments deviceadm deviceauth gui inventory mender-api-gateway-docker useradm" ); do (
 
         case "$build" in
-            deployments|deviceadm|deviceauth|inventory|tenantadm|useradm)
+            deployments*|deviceadm|deviceauth|inventory|tenantadm|useradm*)
                 cd go/src/github.com/mendersoftware/$build
                 # Versions before 2.0.0 used "go build", later ones
                 # build everything inside multi-stage docker builds.
@@ -1161,7 +1161,7 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
             version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD)
             # Upload containers.
             case "$image" in
-                api-gateway|deployments|deviceadm|deviceauth|email-sender|gui|inventory|mender-client-docker|mender-conductor|mender-conductor-enterprise|useradm)
+                api-gateway|deployments*|deviceadm|deviceauth|email-sender|gui|inventory|mender-client-docker|mender-conductor*|useradm*)
                     docker tag mendersoftware/$image:pr mendersoftware/$image:${version}
                     docker push mendersoftware/$image:${version}
                     ;;
@@ -1180,7 +1180,7 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
             version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD)
             # Upload binaries.
             case "$image" in
-                deployments|deviceadm|deviceauth|gui|integration|inventory|mender-api-gateway-docker|mender-conductor*|useradm)
+                deployments*|deviceadm|deviceauth|gui|integration|inventory|mender-api-gateway-docker|mender-conductor*|useradm*)
                     # No binaries.
                     :
                     ;;


### PR DESCRIPTION
```
commit 06d270877c391f8018f2b5a7cda9c27bbe8631dc
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Aug 5 12:45:07 2019 +0200

    Add new -enterprise repos to GitLab Pipeline
    
    And, where possible, use release_tool instead of hardcoded names to
    catch errors earlier next time add enterprise components
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit c828daace1ebba61877eae73a65022b45f128987
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Aug 5 15:12:13 2019 +0200

    Enforce clean workspace and strictly clone the repos
    
    Re-using the slaves have other problems, like the build-* directories
    and others being added to the tarball and resulting in too large files.
    
    Until we find a good way to cache the workspace, let's just enforce a
    clean state before starting.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit 811b6bc750d55e81fd5bd504f98e0705402faad2
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Aug 5 20:46:35 2019 +0200

    Add instructions to build/publish -enterprise repos in QA script
    
    This should have been already in place. Current Jenkins builds are
    pulling from Docker registry instead of building a local image.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```