### PR TITLE
Refactor Github PR status updates running in Gitlab CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -431,8 +431,10 @@ test_accep_qemux86_64_uefi_grub:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html
+    - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -459,8 +461,10 @@ test_accep_vexpress_qemu:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html
+    - if [ "$TEST_VEXPRESS_QEMU" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -486,8 +490,10 @@ test_accep_qemux86_64_bios_grub:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html
+    - if [ "$TEST_QEMUX86_64_BIOS_GRUB" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -513,8 +519,10 @@ test_accep_qemux86_64_bios_grub_gpt:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html
+    - if [ "$TEST_QEMUX86_64_BIOS_GRUB_GPT" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -540,8 +548,10 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html
+    - if [ "$TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -567,8 +577,10 @@ test_accep_vexpress_qemu_flash:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html
+    - if [ "$TEST_VEXPRESS_QEMU_FLASH" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -594,8 +606,10 @@ test_accep_beagleboneblack:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html
+    - if [ "$TEST_BEAGLEBONEBLACK" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
@@ -621,8 +635,10 @@ test_accep_raspberrypi3:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml
-    - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html
+    - if [ "$TEST_RASPBERRYPI3" = "true" ]; then
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml;
+        cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html;
+      fi
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -61,14 +61,23 @@ init_workspace:
   tags:
     - mender-qa-slave
   script:
+    # Default value, will later be overwritten if successful
+    - echo "failure" > /JOB_RESULT.txt
+
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk --update --no-cache add git openssh bash
+    - apk --update --no-cache add git openssh bash python3 curl
+    - pip3 install --upgrade pyyaml
+
     # Prepare SSH keys
     - eval $(ssh-agent -s)
     - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
     - mkdir -p ~/.ssh
     - chmod 700 ~/.ssh
     - ssh-keyscan github.com >> ~/.ssh/known_hosts
+
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+
     # Clean WORKSPACE and clone all repos
     - find ${WORKSPACE}
       -mindepth 1
@@ -80,6 +89,15 @@ init_workspace:
     - git fetch && git checkout -f origin/${POKY_REV}
     - echo -e "# $(git log -n1 --oneline)\nexport POKY_REV=$POKY_REV\nexport POKY_REV_GIT_SHA=$(git rev-parse HEAD)" > ${CI_PROJECT_DIR}/build_revisions.env
 
+    # Add MENDER_QA_REV, which is special, since it is this repository.
+    - if echo "$CI_BUILD_REF_NAME" | egrep '^pr_[0-9]+$'; then
+        export MENDER_QA_REV="pull/$(echo "$CI_BUILD_REF_NAME" | egrep -o '[0-9]+')/head";
+      else
+        export MENDER_QA_REV="$CI_BUILD_REF_NAME";
+      fi
+    - (cd mender-qa && echo -e "# $(git log -n1 --oneline)\nexport MENDER_QA_REV=$MENDER_QA_REV\nexport MENDER_QA_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
+
+    # Add other repositories.
     - git clone https://github.com/mendersoftware/meta-mender
     - (cd meta-mender &&
       git fetch -u -f origin ${META_MENDER_REV}:pr &&
@@ -227,8 +245,14 @@ init_workspace:
     - cat ${CI_PROJECT_DIR}/build_revisions.env
     - tar -czf /tmp/workspace.tar.gz .
     - mv /tmp/workspace.tar.gz ${CI_PROJECT_DIR}/workspace.tar.gz
+
+    # Always keep this at the end of the script stage
+    - echo "success" > /JOB_RESULT.txt
+
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_INIT ${CI_PROJECT_DIR}/WAIT_IN_STAGE_INIT
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+
   artifacts:
     expire_in: 2w
     paths:
@@ -242,6 +266,8 @@ init_workspace:
   tags:
     - mender-qa-slave
   before_script:
+    # Default value, will later be overwritten if successful
+    - echo "failure" > /JOB_RESULT.txt
     # Check correct dind setup
     - docker version
     # Export required yoctobuild script variables
@@ -264,6 +290,8 @@ init_workspace:
       zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev
       libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler
       qemu-system-x86 bc kpartx liblzma-dev cpio sudo awscli
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
     # Prepare mender user
     - useradd -m -u 1010 mender || true
     - mkdir -p /home/mender/.ssh
@@ -322,6 +350,9 @@ init_workspace:
     - export HOME="/home/mender"
     - sudo -E -u mender ${WORKSPACE}/mender-qa/scripts/jenkins-yoctobuild-build.sh
 
+    # Always keep this at the end of the script stage
+    - echo "success" > /JOB_RESULT.txt
+
 build_client:
   stage: build
   dependencies:
@@ -338,6 +369,8 @@ build_client:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
     - docker save mendersoftware/mender-client-qemu:pr -o mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o mender-client-qemu-rofs.tar
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     paths:
@@ -363,6 +396,8 @@ build_servers:
       fi; done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf host-tools.tar -C ../go/bin/ .
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
 
   artifacts:
     expire_in: 2w
@@ -394,6 +429,8 @@ test_accep_qemux86_64_uefi_grub:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -419,6 +456,8 @@ test_accep_vexpress_qemu:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -443,6 +482,8 @@ test_accep_qemux86_64_bios_grub:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -467,6 +508,8 @@ test_accep_qemux86_64_bios_grub_gpt:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -491,6 +534,8 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -515,6 +560,8 @@ test_accep_vexpress_qemu_flash:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -539,6 +586,8 @@ test_accep_beagleboneblack:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -563,6 +612,8 @@ test_accep_raspberrypi3:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always
@@ -585,12 +636,15 @@ test_backend_integration:
     - init_workspace
     - build_servers
   before_script:
+    # Default value, will later be overwritten if successful
+    - echo "failure" > /JOB_RESULT.txt
+
     - /usr/local/bin/dockerd-entrypoint.sh &
     - sleep 10
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
     - apk --update --no-cache add bash git py-pip gcc make python2-dev
-      libc-dev libffi-dev openssl-dev python3
+      libc-dev libffi-dev openssl-dev python3 curl
     - pip install docker-compose==1.24.0
     - pip3 install pyyaml
     - rm -rf /var/cache/apk/*
@@ -602,6 +656,10 @@ test_backend_integration:
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/*.tar .
+
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+
     # Load all docker images except client
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
       if ! echo $repo | grep -q mender-client-qemu; then
@@ -627,8 +685,14 @@ test_backend_integration:
       else
       PYTEST_ARGS="-k 'not Multitenant'" ./run;
       fi
+
+    # Always keep this at the end of the script stage
+    - echo "success" > /JOB_RESULT.txt
+
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
@@ -643,6 +707,9 @@ test_full_integration:
     - build_servers
     - build_client
   before_script:
+    # Default value, will later be overwritten if successful
+    - echo "failure" > /JOB_RESULT.txt
+
     - /usr/local/bin/dockerd-entrypoint.sh &
     - sleep 10
     - export DOCKER_HOST="unix:///var/run/docker.sock"
@@ -664,6 +731,10 @@ test_full_integration:
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/*.tar .
+
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+
     # Install test dependencies
     - pip install pycrypto && pip install -r integration/tests/requirements.txt
     - pip install pytest-xdist --upgrade
@@ -694,10 +765,16 @@ test_full_integration:
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - cd integration/tests
     - ./run.sh --no-download --machine-name qemux86-64
+
+    # Always keep this at the end of the script stage
+    - echo "success" > /JOB_RESULT.txt
+
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   artifacts:
     expire_in: 2w
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -251,6 +251,7 @@ init_workspace:
 
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_INIT ${CI_PROJECT_DIR}/WAIT_IN_STAGE_INIT
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
 
   artifacts:
@@ -367,6 +368,7 @@ build_client:
       - $RUN_INTEGRATION_TESTS == "true"
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - docker save mendersoftware/mender-client-qemu:pr -o mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o mender-client-qemu-rofs.tar
     # Post job status
@@ -390,6 +392,7 @@ build_servers:
       - $RUN_INTEGRATION_TESTS == "true"
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
       if ! echo $repo | grep -q mender-client-qemu; then
       docker save mendersoftware/${repo}:pr -o ${repo}.tar;
@@ -427,6 +430,7 @@ test_accep_qemux86_64_uefi_grub:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html
     # Post job status
@@ -454,6 +458,7 @@ test_accep_vexpress_qemu:
     JOB_BASE_NAME: mender_vexpress_qemu
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html
     # Post job status
@@ -480,6 +485,7 @@ test_accep_qemux86_64_bios_grub:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html
     # Post job status
@@ -506,6 +512,7 @@ test_accep_qemux86_64_bios_grub_gpt:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html
     # Post job status
@@ -532,6 +539,7 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html
     # Post job status
@@ -558,6 +566,7 @@ test_accep_vexpress_qemu_flash:
     JOB_BASE_NAME: mender_vexpress_qemu_flash
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html
     # Post job status
@@ -584,6 +593,7 @@ test_accep_beagleboneblack:
     JOB_BASE_NAME: mender_beagleboneblack
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html
     # Post job status
@@ -610,6 +620,7 @@ test_accep_raspberrypi3:
     JOB_BASE_NAME: mender_raspberrypi3
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml
     - cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html
     # Post job status
@@ -691,6 +702,7 @@ test_backend_integration:
 
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
   only:
@@ -771,6 +783,7 @@ test_full_integration:
 
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
     # Post job status

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+if [ "$DISABLE_GITHUB_PULL_REQUEST_STATUS" != "" ]; then
+    exit 0
+fi
+
+request_body=$(cat <<EOF
+{
+  "state": "$1",
+  "description": "$2",
+  "target_url": "$3",
+  "context": "$4"
+}
+EOF
+)
+
+# Special case for mender-qa running in Gitlab: It builds a specific branch, not
+# by setting the MENDER_QA_REV variables, but by simply checking out that
+# branch. It is recorded in the "CI_*" variables though.
+if [ "$CI_PROJECT_NAME" = "mender-qa" ]; then
+    if echo "$CI_BUILD_REF_NAME" | egrep '^pr_[0-9]+$'; then
+        export MENDER_QA_REV="pull/$(echo "$CI_BUILD_REF_NAME" | egrep -o '[0-9]+')/head"
+    else
+        export MENDER_QA_REV="$CI_BUILD_REF_NAME"
+    fi
+fi
+
+# Split on newlines
+IFS='
+'
+for key in $(compgen -A export); do
+    if ! eval echo \$$key | egrep -q "^pull/[0-9]+/head$"; then
+        # Not a pull request, skip.
+        continue
+    fi
+    if echo $key | egrep -q "^DOCKER_ENV_"; then
+        # Skip GitLab/Docker duplicated environment vars, i.e. MENDER_REV has a DOCKER_ENV_MENDER_REV
+        continue
+    fi
+
+    repo=$(tr '[A-Z_]' '[a-z-]' <<<${key%_REV})
+    if [ -n "$(eval echo \$${key}_GIT_SHA)" ]; then
+        # GitLab script defines env variables with _GIT_SHA suffix for the PR commit under test
+        git_commit="$(eval echo \$${key}_GIT_SHA)"
+    else
+        # Fallback to classic method of relying on locally cloned repos
+        case "$key" in
+            META_MENDER_REV)
+                location=$WORKSPACE/meta-mender
+                ;;
+            *_REV)
+                if ! $WORKSPACE/integration/extra/release_tool.py --version-of $repo; then
+                    # If the release tool doesn't recognize the repository, don't use it.
+                    continue
+                fi
+                location=
+                if [ -d "$WORKSPACE/$repo" ]; then
+                    location="$WORKSPACE/$repo"
+                elif [ -d "$WORKSPACE/go/src/github.com/mendersoftware/$repo" ]; then
+                    location="$WORKSPACE/go/src/github.com/mendersoftware/$repo"
+                else
+                    echo "github_pull_request_status: Unable to find repository location: $repo"
+                    return 1
+                fi
+                ;;
+            *)
+                # Not a revision, go to next entry.
+                continue
+                ;;
+        esac
+        git_commit=$(cd "$location" && git rev-parse HEAD)
+    fi
+    pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
+
+    curl -iv --user "$GITHUB_BOT_USER:$GITHUB_BOT_PASSWORD" \
+         -d "$request_body" \
+         "$pr_status_endpoint"
+done
+

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -45,6 +45,9 @@ for key in $(compgen -A export); do
     else
         # Fallback to classic method of relying on locally cloned repos
         case "$key" in
+            MENDER_QA_REV)
+                location=$WORKSPACE/mender-qa
+                ;;
             META_MENDER_REV)
                 location=$WORKSPACE/meta-mender
                 ;;


### PR DESCRIPTION
```
commit 919b206537e1f01e3265585a4fe7c93404630081
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Aug 29 11:05:20 2019

    Add MENDER_QA_REV as eligible candidate for PR status updates.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 3f3456d1c6043c0b4ff6d0b2672871a6aa1ad7da
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Thu Aug 29 10:42:13 2019

    Refactor Github PR status updates running in Gitlab CI.
    
    This makes it more robust and less reliant on the enormous
    `jenkins-yoctobuild-build` script. The actual posting code is moved to
    its own file, and both CI providers call this. Note however, that we
    disable updates from within jenkins-yoctobuild-build for Gitlab CI,
    and instead rely on its `before_script` and `after_script`
    sections. This should make it better at updating the status in the
    case of failures.
    
    There are a few weaknesses with this approach:
    
    * Because we can no longer update the `TEST_TRACKER` variable from an
      external script, Jenkins is now unable to post failure updates using
      the shell trap, which means that only pure build and test failures
      will be reported. This was not fullproof before either though. I
      think this is a reasonable tradeoff, since we are moving away from
      Jenkins.
    
    * If a step in the `after_script` fails, then the status will not be
      posted from Gitlab CI. It is possible to fix this by using `||
      ret=$?` style of commands, but it is messy, and will cause extra
      commands to execute when in fact, it should stop. I think this is
      also a reasonable tradeoff, since the `after_script` sections are
      short, much less likely to fail, and it will be visible on Github
      still, just as an unfinished job, rather than a failed one.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```