### PR TITLE
Fixes while porting meta-mender-commercial to sumo and rocko

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -753,7 +753,10 @@ build_and_test_client() {
 
             local pytest_args=
             if ! ( is_poky_branch morty || is_poky_branch pyro || is_poky_branch rocko || is_poky_branch sumo ); then
-                pytest_args="--no-pull --commercial-tests"
+                pytest_args="--no-pull"
+            fi
+            if ! ( is_poky_branch morty || is_poky_branch pyro ); then
+                pytest_args="$pytest_args --commercial-tests"
             fi
 
             # run tests with xdist explicitly disabled

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -226,8 +226,14 @@ EOF
 MENDER_ARTIFACT_NAME = "mender-image-$client_version"
 EOF
 
-    local mender_on_exact_tag=$(test "$MENDER_REV" != "master" && cd $WORKSPACE/go/src/github.com/mendersoftware/mender && git describe --tags --exact-match HEAD 2>/dev/null) || mender_on_exact_tag=
-    local mender_artifact_on_exact_tag=$(test "$MENDER_ARTIFACT_REV" != "master" && cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && git describe --tags --exact-match HEAD 2>/dev/null) || mender_artifact_on_exact_tag=
+    local mender_on_exact_tag=$(test "$MENDER_REV" != "master" && \
+        cd $WORKSPACE/go/src/github.com/mendersoftware/mender && \
+        git tag --points-at HEAD 2>/dev/null | egrep ^"$MENDER_REV"$ ) || \
+        mender_on_exact_tag=
+    local mender_artifact_on_exact_tag=$(test "$MENDER_ARTIFACT_REV" != "master" && \
+        cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && \
+        git tag --points-at HEAD 2>/dev/null | egrep ^"$MENDER_ARTIFACT_REV"$ ) || \
+        mender_artifact_on_exact_tag=
 
     # Setting these PREFERRED_VERSIONs doesn't influence which version we build,
     # since we are building the one that Jenkins has cloned, but it does


### PR DESCRIPTION
```
commit af19f82bff3044e1c46d74858f077735ef729882
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Sep 16 14:21:29 2019 +0200

    Fix exact tag detection when the commit has several tags
    
    By design, git describe will always pick up the latest tag. Use git tag
    "points at" functionality to allow for MENDER_REV to be and old tag
    which points to a commit shared by newer tags.
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>

commit a9a49529c4f551dae1265a527bdfa02d3f576918
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Sep 16 18:16:17 2019 +0200

    Support running mender-binary-delta tests on sumo and rocko
    
    Changelog: None
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```