### PR TITLE
Include branch information in Github statuses from Gitlab CI.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ init_workspace:
     - ssh-keyscan github.com >> ~/.ssh/known_hosts
 
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Clean WORKSPACE and clone all repos
     - find ${WORKSPACE}
@@ -252,7 +252,7 @@ init_workspace:
   after_script:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_INIT ${CI_PROJECT_DIR}/WAIT_IN_STAGE_INIT
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -325,7 +325,7 @@ init_workspace:
     - pip3 install --upgrade pyyaml
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
     # Locales
     - apt-get install locales
     - locale-gen --purge en_US.UTF-8
@@ -392,7 +392,7 @@ build_client:
     - docker save mendersoftware/mender-client-qemu:pr -o mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o mender-client-qemu-rofs.tar
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     paths:
@@ -420,7 +420,7 @@ build_servers:
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf host-tools.tar -C ../go/bin/ .
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -456,7 +456,7 @@ test_accep_qemux86_64_uefi_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -486,7 +486,7 @@ test_accep_vexpress_qemu:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -515,7 +515,7 @@ test_accep_qemux86_64_bios_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -544,7 +544,7 @@ test_accep_qemux86_64_bios_grub_gpt:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -573,7 +573,7 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -602,7 +602,7 @@ test_accep_vexpress_qemu_flash:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -631,7 +631,7 @@ test_accep_beagleboneblack:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -660,7 +660,7 @@ test_accep_raspberrypi3:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html;
       fi
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always
@@ -705,7 +705,7 @@ test_backend_integration:
     - mv /tmp/build_revisions.env /tmp/*.tar .
 
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images except client
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
@@ -740,7 +740,7 @@ test_backend_integration:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
@@ -781,7 +781,7 @@ test_full_integration:
     - mv /tmp/build_revisions.env /tmp/*.tar .
 
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "${CI_JOB_NAME} started" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Install test dependencies
     - pip install pycrypto && pip install -r integration/tests/requirements.txt
@@ -823,7 +823,7 @@ test_full_integration:
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
     # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "${CI_JOB_NAME} finished" "${CI_JOB_URL}" "Gitlab_${CI_JOB_NAME}"
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     when: always


### PR DESCRIPTION
This is important when non-master configurations are tested.

The text space is quite limited, so also remove the "Gitlab_" prefix
and move it to the description. Most people should know it's Gitlab by
now.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>