### PR TITLE
Refactor container handling code to support non-mendersoftware links.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -702,6 +702,7 @@ test_backend_integration:
       fi; done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+    - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
       integration/extra/release_tool.py --set-version-of $repo --version pr;
@@ -796,6 +797,7 @@ test_full_integration:
       done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+    - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
       integration/extra/release_tool.py --set-version-of $repo --version pr;

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -417,7 +417,8 @@ build_servers:
     - mkdir -p stage-artifacts
     - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
       if ! echo $repo | grep -q mender-client-qemu; then
-      docker save mendersoftware/${repo}:pr -o stage-artifacts/${repo}.tar;
+      docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
+      docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
       fi; done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf stage-artifacts/host-tools.tar -C ../go/bin/ .

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -334,6 +334,7 @@ fi
 
 # private docker containers, require login:
 docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
 
 # if we abort a build, docker might still be up and running
 docker ps -q -a | xargs -r docker stop || true

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -1123,8 +1123,6 @@ cd $WORKSPACE/integration
 git checkout -f -- .
 
 if [ "$PUBLISH_ARTIFACTS" = true ]; then
-    docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
-
     if grep mender_servers <<<"$JOB_BASE_NAME"; then
         # Use release tool to query for available repositories, and fall back to
         # flat list for branches where we don't have that option.

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -402,7 +402,7 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
 
         case "$docker" in
-            deployments*|deviceadm*|deviceauth*|inventory*|tenantadm*|useradm*)
+            deployments|deployments-enterprise|deviceauth|inventory|tenantadm|useradm|useradm-enterprise)
                 cd go/src/github.com/mendersoftware/$git
                 # Versions before 2.0.0 used "go build", later ones
                 # build everything inside multi-stage docker builds.
@@ -448,21 +448,15 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
-            mender-conductor)
+            mender-conductor|mender-conductor-enterprise)
                 cd go/src/github.com/mendersoftware/$git
-                docker build -t $docker_url:pr ./server
+                docker build --build-arg REVISION=pr -t $docker_url:pr ./server
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             email-sender)
                 cd go/src/github.com/mendersoftware/$git
                 docker build -t $docker_url:pr ./workers/send_email
-                $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
-                ;;
-
-            mender-conductor-enterprise)
-                cd go/src/github.com/mendersoftware/$git
-                docker build --build-arg REVISION=pr -t $docker_url:pr ./server
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
@@ -1151,7 +1145,7 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
             docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url)
             # Upload containers.
             case "$image" in
-                api-gateway|deployments*|deviceadm|deviceauth|email-sender|gui|inventory|mender-client-docker|mender-conductor*|org-welcome-email-preparer|tenantadm*|useradm*)
+                api-gateway|deployments|deployments-enterprise|deviceauth|email-sender|gui|inventory|mender-client-docker|mender-conductor|mender-conductor-enterprise|org-welcome-email-preparer|tenantadm|useradm|useradm-enterprise)
                     docker tag $docker_url:pr $docker_url:${version}
                     docker push $docker_url:${version}
                     ;;
@@ -1170,7 +1164,7 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
             version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD)
             # Upload binaries.
             case "$image" in
-                deployments*|deviceadm|deviceauth|gui|integration|inventory|mender-api-gateway-docker|mender-conductor*|tenantadm*|useradm*)
+                deployments|deployments-enterprise|deviceauth|gui|integration|inventory|mender-api-gateway-docker|mender-conductor|mender-conductor-enterprise|tenantadm|useradm|useradm-enterprise)
                     # No binaries.
                     :
                     ;;


### PR DESCRIPTION
```
commit 7db631b9d85d1793cd0dfa6249f09cd4a12d42f8
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 15:38:28 2019

    Refactor container handling code to support non-mendersoftware links.
    
    First off we switch to using `release_tool.py --list docker` instead
    of `git`, since there is no 1-to-1 relationship between our git repos
    and Docker images, so this makes it a bit clearer. For the git-only
    services we now have a separate section.
    
    Second we use the new `release_tool.py --map-name` to find the correct
    Docker URL to push.
    
    Also remove the fallback for when `--list` didn't exist. This was
    added in 1.4.x which has not been supported for a long time already.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit 6ede4cd16787b3a94e53520e21ac629b6a478fb8
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 15:35:11 2019

    Add docker login step for registry.mender.io.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>

commit ab03ccf33504bd6263b09df31d1a9746574d7f4d
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Mon Oct 14 15:34:18 2019

    Remove redundant docker login step, already done at the top.
    
    Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```