### PR TITLE
Work around shell logic bug in Gitlab, producing false test negatives.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -719,7 +719,7 @@ test_backend_integration:
       case $INTEGRATION_TEST_SUITE in
       "enterprise") PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run -f=../docker-compose.enterprise.yml -f=../docker-compose.storage.minio.yml ;;
       "open") PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;;
-      *) PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run &&
+      *) PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;
       PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run -f=../docker-compose.enterprise.yml -f=../docker-compose.storage.minio.yml ;;
       esac
       else


### PR DESCRIPTION
For some reason "false && false" produces true in Gitlab, whereas
"false; false" doesn't ('sh -e' behavior). There are more sections
with '&&', but none of them are critical, and I don't feel like
cleaning them up now, especially since it is really a Gitlab bug.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>