### PR TITLE
Install Python dependency pymongo for integ tests

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -949,6 +949,11 @@ upload_output() {
 #                 name can have several boards)
 # ------------------------------------------------------------------------------
 run_integration_tests() {
+
+    # Install Python dependency pymongo.
+    # This is a Jenkins specific hack to not mofidy jenkins-yoctobuild-init-script.sh and rebuild the image
+    sudo pip2 install pymongo==3.6.1
+
     (
         local machine_name="$1"
         local board_name="$2"


### PR DESCRIPTION
This is a hack for Jenkins run of the tests, to not modify the init
script and rebuild the image in Google Cloud Platform.

GitLab runs will not be affected by it, as they don't use this function
to run integration tests.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>