### PR TITLE
Add client trigger and misc

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -277,12 +277,11 @@ init_workspace:
     # Export required yoctobuild script variables
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - export GOPATH="$WORKSPACE/go"
-    # This template is used in both build and acc test stages
+    # This template is used in both build and acc test stages,
+    # for build stage, force default configuration QEMUX86_64_UEFI_GRUB
+    - test -n "$ONLY_BUILD" && export BUILD_QEMUX86_64_UEFI_GRUB=true
     - test -n "$ONLY_BUILD" && export TEST_QEMUX86_64_UEFI_GRUB=false
-    - test -n "$ONLY_BUILD" && export TEST_VEXPRESS_QEMU=false
     - export RUN_INTEGRATION_TESTS=false
-    # Always force building the client, default to BUILD_QEMUX86_64_UEFI_GRUB
-    - test "$BUILD_QEMUX86_64_UEFI_GRUB" != "true" -a "$BUILD_VEXPRESS_QEMU" != true && export BUILD_QEMUX86_64_UEFI_GRUB=true
     # basic tools
     - apt-get update -q
     - apt-get install -qqy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ variables:
   SPECIFIC_INTEGRATION_TEST: ""
   TESTS_IN_PARALLEL: "4"
   XDIST_PARALLEL_ARG: "4" #TODO: Unify these two parameters
-  PUBLISH_ARTIFACTS: ""
+  PUBLISH_ARTIFACTS: "false"
   WAIT_IN_STAGE_INIT: ""
   WAIT_IN_STAGE_BUILD: ""
   WAIT_IN_STAGE_TEST: ""
@@ -281,6 +281,7 @@ init_workspace:
     # for build stage, force default configuration QEMUX86_64_UEFI_GRUB
     - test -n "$ONLY_BUILD" && export BUILD_QEMUX86_64_UEFI_GRUB=true
     - test -n "$ONLY_BUILD" && export TEST_QEMUX86_64_UEFI_GRUB=false
+    - test -n "$ONLY_BUILD" && export PUBLISH_ARTIFACTS=false
     - export RUN_INTEGRATION_TESTS=false
     # basic tools
     - apt-get update -q

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -283,8 +283,6 @@ init_workspace:
     - export RUN_INTEGRATION_TESTS=false
     # Always force building the client, default to BUILD_QEMUX86_64_UEFI_GRUB
     - test "$BUILD_QEMUX86_64_UEFI_GRUB" != "true" -a "$BUILD_VEXPRESS_QEMU" != true && export BUILD_QEMUX86_64_UEFI_GRUB=true
-    # Prepare tzdata unatended configuration
-    - ln -fs /usr/share/zoneinfo/Europe/Oslo /etc/localtime
     # basic tools
     - apt-get update -q
     - apt-get install -qqy

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+mender_version=$1
+
+if [ -z "$mender_version" ]; then
+  echo "Usage: $0 mender-version"
+  exit 1
+fi
+
+if [ -z "$MENDER_QA_TRIGGER_TOKEN" ]; then
+  echo "MENDER_QA_TRIGGER_TOKEN not found in environment"
+  exit 1
+fi
+
+if [ ! -d $WORKSPACE/integration ]; then
+  echo "integration repo not found, expected at \$WORKSPACE/integration"
+  exit 1
+fi
+
+
+# For each integration version including mender version $mender_version:
+# * construct a curl formatted string concatenating each repo and revision like:
+#   '-F variables[repoA_REV]=X.X.x -F variables[repoB_REV]=X.X.x ...'
+# * trigger a Mender QA pipeline to build/test/publish client
+
+integration_versions=$($WORKSPACE/integration/extra/release_tool.py \
+                       --integration-versions-including mender \
+                       --version $mender_version)
+
+for integ_version in $integration_versions; do
+
+  variables_revs=""
+
+  all_repos=$($WORKSPACE/integration/extra/release_tool.py --list git)
+
+  for repo in $all_repos; do
+    repo_version=$($WORKSPACE/integration/extra/release_tool.py \
+                   --version-of $repo \
+                   --in-integration-version $integ_version |
+                   cut -d/ -f2);
+    variables_revs="$variables_revs $(echo -n -F variables[; \
+                    echo -n $repo | tr '[a-z-]' '[A-Z_]'; \
+                    echo _REV]=${repo_version})";
+  done
+
+  curl -f -X POST \
+    -F token=$MENDER_QA_TRIGGER_TOKEN \
+    -F ref=master \
+    -F variables[PUBLISH_ARTIFACTS]=true \
+    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=true \
+    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=true \
+    -F variables[BUILD_QEMUX86_64_BIOS_GRUB]=false \
+    -F variables[TEST_QEMUX86_64_BIOS_GRUB]=false \
+    -F variables[BUILD_QEMUX86_64_BIOS_GRUB_GPT]=false \
+    -F variables[TEST_QEMUX86_64_BIOS_GRUB_GPT]=false \
+    -F variables[BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB]=false \
+    -F variables[TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB]=false \
+    -F variables[BUILD_VEXPRESS_QEMU]=false \
+    -F variables[TEST_VEXPRESS_QEMU]=false \
+    -F variables[BUILD_VEXPRESS_QEMU_FLASH]=false \
+    -F variables[TEST_VEXPRESS_QEMU_FLASH]=false \
+    -F variables[BUILD_BEAGLEBONEBLACK]=false \
+    -F variables[TEST_BEAGLEBONEBLACK]=false \
+    -F variables[BUILD_RASPBERRYPI3]=false \
+    -F variables[TEST_RASPBERRYPI3]=false \
+    -F variables[RUN_INTEGRATION_TESTS]=false \
+    $variables_revs \
+    https://gitlab.com/api/v4/projects/12501706/trigger/pipeline
+
+done


### PR DESCRIPTION
The most important commit:

```
commit ea07da300835b0e77027587f3a172f408eab13ae
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Mon Oct 21 15:31:47 2019 +0200

    Add GitLab script to trigger client builds publishing artifacts.
    
    The mender client Pipeline is special in the sense that no acceptance
    tests (nor full yocto build, for all that matters) is done in the
    individual repo. So we will need this script to trigger a part of the
    mender-qa Pipeline with publishing logic enable.
    
    Using release_tool from integration repo, construct a string with all
    parameters for the curl call(s) specifiying the correct versions for
    each repo.
    
    Note that this might lead to more than one pipeline if the client
    release branch target is used in more than one Mender integration
    
    Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```

Tested together with https://github.com/mendersoftware/mender/pull/441