### PR TITLE
Unify installation of the integration-test dependencies

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -827,7 +827,6 @@ test_full_integration:
       done
     # Other dependencies
     - tar -xf stage-artifacts/host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/
-    - tar -xf stage-artifacts/host-tools.tar ./mender-stress-test-client && mv mender-stress-test-client /usr/local/bin/
     - tar -xf stage-artifacts/host-tools.tar ./directory-artifact-gen && mv directory-artifact-gen /usr/local/bin/
   script:
     # Traps only work if executed in a sub shell.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -795,11 +795,7 @@ test_full_integration:
     - sleep 10
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
-    - apk --update --no-cache add bash curl git openssh device-mapper py-pip
-      iptables gcc python2-dev libffi-dev libc-dev openssl-dev make python3
-      python3-dev e2fsprogs-extra openssl jq libc6-compat
-    - pip install docker-compose==1.24.0
-    - pip3 install pyyaml
+
     - rm -rf /var/cache/apk/*
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -810,13 +806,14 @@ test_full_integration:
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
+    # Get and install the integration test requirements
+    - apk --update --no-cache add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
+    - pip install  -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
+    - pip3 install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
+
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
-    # Install test dependencies
-    - pip install pycrypto && pip install -r integration/tests/requirements.txt
-    - pip install pytest-xdist --upgrade
-    - pip install pytest-html --upgrade
     # Load all docker images
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
       docker load -i stage-artifacts/${repo}.tar;


### PR DESCRIPTION
This makes the integration-test-slave install its Python and Alpine dependencies
from the `tests/requirements/` files in the `integration` repo.

This approach unifies the dependency management for integration tests, and
collects them at one place, simplifying dependency management.

The requirements files are simply wget'd from the Github integration repo.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>