### PR TITLE
Fix `WAIT_IN_STAGE` mechanism which times out after 5 min.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,8 +63,16 @@ init_workspace:
   tags:
     - mender-qa-slave
   script:
+    # Traps only work if executed in a sub shell.
+    - "("
+
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
+
+    - function handle_exit() {
+      ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_INIT ${CI_PROJECT_DIR}/WAIT_IN_STAGE_INIT;
+      };
+      trap handle_exit EXIT
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update --no-cache add git openssh bash python3 curl
@@ -252,8 +260,9 @@ init_workspace:
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
 
+    - ")"
+
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_INIT ${CI_PROJECT_DIR}/WAIT_IN_STAGE_INIT
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
@@ -362,11 +371,23 @@ init_workspace:
     - modprobe -r kvm_intel
     - modprobe kvm_intel nested=Y
   script:
+    # Traps only work if executed in a sub shell.
+    - "("
     - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
+
+    - function handle_exit() {
+      if test -n "$ONLY_BUILD"; then
+      ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD;
+      else
+      ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST;
+      fi;
+      };
+      trap handle_exit EXIT
+
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - chown -R mender:mender ${WORKSPACE}
     - export HOME="/home/mender"
@@ -374,6 +395,8 @@ init_workspace:
 
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
+
+    - ")"
 
 build_client:
   stage: build
@@ -388,7 +411,6 @@ build_client:
       - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
       - $RUN_INTEGRATION_TESTS == "true"
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
@@ -412,7 +434,6 @@ build_servers:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mkdir -p stage-artifacts
     - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
@@ -438,7 +459,6 @@ test_accep_qemux86_64_uefi_grub:
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml;
@@ -468,7 +488,6 @@ test_accep_vexpress_qemu:
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_VEXPRESS_QEMU" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml;
@@ -497,7 +516,6 @@ test_accep_qemux86_64_bios_grub:
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml;
@@ -526,7 +544,6 @@ test_accep_qemux86_64_bios_grub_gpt:
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB_GPT" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml;
@@ -555,7 +572,6 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml;
@@ -584,7 +600,6 @@ test_accep_vexpress_qemu_flash:
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_flash
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_VEXPRESS_QEMU_FLASH" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml;
@@ -613,7 +628,6 @@ test_accep_beagleboneblack:
   variables:
     JOB_BASE_NAME: mender_beagleboneblack
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_BEAGLEBONEBLACK" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml;
@@ -642,7 +656,6 @@ test_accep_raspberrypi3:
   variables:
     JOB_BASE_NAME: mender_raspberrypi3
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$TEST_RASPBERRYPI3" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml;
@@ -709,6 +722,14 @@ test_backend_integration:
       integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
   script:
+    # Traps only work if executed in a sub shell.
+    - "("
+
+    - function handle_exit() {
+      ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST;
+      };
+      trap handle_exit EXIT
+
     - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
     - cd integration/backend-tests/
 
@@ -731,8 +752,9 @@ test_backend_integration:
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
 
+    - ")"
+
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
@@ -805,6 +827,14 @@ test_full_integration:
     - tar -xf stage-artifacts/host-tools.tar ./mender-stress-test-client && mv mender-stress-test-client /usr/local/bin/
     - tar -xf stage-artifacts/host-tools.tar ./directory-artifact-gen && mv directory-artifact-gen /usr/local/bin/
   script:
+    # Traps only work if executed in a sub shell.
+    - "("
+
+    - function handle_exit() {
+      ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST;
+      };
+      trap handle_exit EXIT
+
     - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
     # only do automatic test suite selection if the user wasn't specific
     # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
@@ -820,8 +850,9 @@ test_full_integration:
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
 
+    - ")"
+
   after_script:
-    - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_TEST ${CI_PROJECT_DIR}/WAIT_IN_STAGE_TEST
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html


### PR DESCRIPTION
Supersedes #322 

Same change set but rebasing on top of master.

```
commit d289beccc6b63e7c71efca0e8dad8b64f9570916
Author: Kristian Amlie <kristian.amlie@northern.tech>
Date:   Fri Nov 8 14:09:54 2019 +0100

    Fix `WAIT_IN_STAGE` mechanism which times out after 5 min.

`after_script` apparently has a hardcoded timeout of 5 min, which
cannot be changed. Luckily `trap` works in Gitlab scripts if we
execute the whole script in a subshell, so use that to trap shell exit
and wait inside the `script` section instead.

There is a contribution to Gitlab open which fixes the issue without
using a subshell, but this is not merged at the time of writing:
https://gitlab.com/gitlab-org/gitlab-runner/merge_requests/971

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>
```