### PR TITLE
QA-111: Check signoffs in community repositories

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,12 @@ variables:
 
   DEBIAN_FRONTEND: noninteractive
 
+# Check signoffs in commits
+include:
+    - project: 'Northern.tech/Mender/mendertesting'
+      ref: master
+      file: '.gitlab-ci-check-commits-signoffs.yml'
+
 stages:
   - init
   - build


### PR DESCRIPTION
Includes the '.gitlab-ci-check-commits-signoffs.yml' file from 'mendertesting',
to verify that all commits includes a signoff.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>