### PR TITLE
Add support to build servers pre-enterprise (master)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -398,7 +398,7 @@ build_client:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
-    - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
+    - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar || true
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -421,11 +421,16 @@ build_servers:
     - ${CI_PROJECT_DIR}/scripts/maybe-wait-in-stage.sh WAIT_IN_STAGE_BUILD ${CI_PROJECT_DIR}/WAIT_IN_STAGE_BUILD
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mkdir -p stage-artifacts
-    - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
-      if ! echo $repo | grep -q mender-client-qemu; then
-      docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
-      docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
-      fi; done
+    - for repo in $(${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a | grep -v deviceadm); do
+        if ! echo $repo | grep -q mender-client-qemu; then
+          if ${CI_PROJECT_DIR}/../integration/extra/release_tool.py --help | grep -e '--map-name FROM-TYPE SERVICE TO-TYPE'; then
+            docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
+          else
+            docker_url="mendersoftware/${repo}";
+          fi;
+          docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
+        fi;
+      done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf stage-artifacts/host-tools.tar -C ../go/bin/ .
     # Post job status
@@ -703,16 +708,17 @@ test_backend_integration:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images except client
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      if ! echo $repo | grep -q mender-client-qemu; then
-      docker load -i stage-artifacts/${repo}.tar;
-      fi; done
+    - for repo in $(integration/extra/release_tool.py -l docker -a | grep -v deviceadm); do
+        if ! echo $repo | grep -q mender-client-qemu; then
+          docker load -i stage-artifacts/${repo}.tar;
+        fi;
+      done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      integration/extra/release_tool.py --set-version-of $repo --version pr;
+    - for repo in $(integration/extra/release_tool.py -l docker -a | grep -v deviceadm); do
+        integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
   script:
     - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
@@ -796,15 +802,15 @@ test_full_integration:
     - pip install pytest-xdist --upgrade
     - pip install pytest-html --upgrade
     # Load all docker images
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      docker load -i stage-artifacts/${repo}.tar;
+    - for repo in $(integration/extra/release_tool.py -l docker -a | grep -v deviceadm); do
+        docker load -i stage-artifacts/${repo}.tar;
       done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      integration/extra/release_tool.py --set-version-of $repo --version pr;
+    - for repo in $(integration/extra/release_tool.py -l docker -a | grep -v deviceadm); do
+        integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
     # Other dependencies
     - tar -xf stage-artifacts/host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -361,8 +361,19 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
     # Use release tool to query for available docker names.
     for docker in $($WORKSPACE/integration/extra/release_tool.py --list docker -a ); do (
 
-        git=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker git)
-        docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
+        if $WORKSPACE/integration/extra/release_tool.py --help | grep -e '--map-name FROM-TYPE SERVICE TO-TYPE'; then
+            git=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker git)
+            docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
+        else
+            case "$docker" in
+                mender-client-docker) git="mender";;
+                api-gateway) git="mender-api-gateway-docker";;
+                email-sender) git="mender-conductor";;
+                org-welcome-email-preparer) git="mender-conductor-enterprise";;
+                *) git="${docker}";;
+            esac
+            docker_url="mendersoftware/${docker}"
+        fi
 
         case "$docker" in
             deployments|deployments-enterprise|deviceauth|inventory|tenantadm|useradm|useradm-enterprise)
@@ -429,6 +440,10 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
+            deviceadm)
+                # Abandonded microservice, do nothing
+                :
+                ;;
             *)
                 echo "Don't know how to build docker image $docker"
                 exit 1
@@ -1105,7 +1120,11 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
         # Use release tool to query for available docker images.
         for image in $($WORKSPACE/integration/extra/release_tool.py --list docker ); do (
             version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD)
-            docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url)
+            if $WORKSPACE/integration/extra/release_tool.py --help | grep -e '--map-name FROM-TYPE SERVICE TO-TYPE'; then
+                docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url)
+            else
+                docker_url="mendersoftware/${repo}"
+            fi
             # Upload containers.
             case "$image" in
                 api-gateway|deployments|deployments-enterprise|deviceauth|email-sender|gui|inventory|mender-client-docker|mender-conductor|mender-conductor-enterprise|org-welcome-email-preparer|tenantadm|useradm|useradm-enterprise)
@@ -1114,6 +1133,10 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
                     ;;
                 mender-client-qemu|mender-client-qemu-rofs)
                     # Handled below.
+                    :
+                    ;;
+                deviceadm)
+                    # Abandonded microservice, do nothing
                     :
                     ;;
                 *)
@@ -1139,6 +1162,10 @@ if [ "$PUBLISH_ARTIFACTS" = true ]; then
                     ;;
                 mender-artifact|mender)
                     # Handled in publish_artifacts().
+                    :
+                    ;;
+                deviceadm)
+                    # Abandonded microservice, do nothing
                     :
                     ;;
                 *)


### PR DESCRIPTION
```
Add support to build servers pre-enterprise

At the time, we introduced a new flag to map docker-to-git names in our
release_tool. The build scripts were updated accordingly, but not in a
backwards compatible manner. See commit 2cc785a.

This commit adds some logic to detect if the release_tool in the
integration version in use has support for such functionality. It also
adds ignore cases for deviceadm as old integration versions will list
it, unfortunately.

Changelog: None

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>
```