### PR TITLE
Use two runners and memory monitor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -286,7 +286,7 @@ init_workspace:
   services:
   - docker:18-dind
   tags:
-    - mender-qa-slave
+    - mender-qa-slave-highcpu
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -720,7 +720,7 @@ test_backend_integration:
   stage: test
   image: docker:18-dind
   tags:
-    - mender-qa-slave
+    - mender-qa-slave-highcpu
   dependencies:
     - init_workspace
     - build_servers
@@ -826,7 +826,7 @@ test_full_integration:
   stage: test
   image: docker:18-dind
   tags:
-    - mender-qa-slave
+    - mender-qa-slave-highmem
   dependencies:
     - init_workspace
     - build_servers

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -353,9 +353,9 @@ init_workspace:
     - export LANGUAGE=en_US.UTF-8
     # debugfs
     - cp /sbin/debugfs /usr/bin/ || echo "debugfs not in /sbin/"
-    # sysstat monitoring suite
+    # sysstat monitoring suite for Debian/Ubuntu
     # collect cpu, load avg, memory and io usage every 2 secs forever
-    # use 'sar' from sysstat to render the result file (~/sysstat.log) manually
+    # use 'sar' from sysstat to render the result file manually
     - apt-get install -qqy sysstat
     - sed -i 's/false/true/g' /etc/default/sysstat
     - service sysstat start
@@ -415,12 +415,16 @@ build_client:
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
     expire_in: 2w
     paths:
       - stage-artifacts/
+      - sysstat.log
+      - sysstat.svg
 
 build_servers:
   stage: build
@@ -443,6 +447,8 @@ build_servers:
       fi; done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf stage-artifacts/host-tools.tar -C ../go/bin/ .
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
@@ -450,6 +456,8 @@ build_servers:
     expire_in: 2w
     paths:
       - stage-artifacts/
+      - sysstat.log
+      - sysstat.svg
 
 test_accep_qemux86_64_uefi_grub:
   stage: test
@@ -464,6 +472,8 @@ test_accep_qemux86_64_uefi_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -472,6 +482,8 @@ test_accep_qemux86_64_uefi_grub:
     paths:
       - results_accep_qemux86_64_uefi_grub.xml
       - report_accep_qemux86_64_uefi_grub.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_qemux86_64_uefi_grub.xml
   only:
@@ -493,6 +505,8 @@ test_accep_vexpress_qemu:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -501,6 +515,8 @@ test_accep_vexpress_qemu:
     paths:
       - results_accep_vexpress_qemu.xml
       - report_accep_vexpress_qemu.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_vexpress_qemu.xml
   only:
@@ -521,6 +537,8 @@ test_accep_qemux86_64_bios_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -529,6 +547,8 @@ test_accep_qemux86_64_bios_grub:
     paths:
       - results_accep_qemux86_64_bios_grub.xml
       - report_accep_qemux86_64_bios_grub.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_qemux86_64_bios_grub.xml
   only:
@@ -549,6 +569,8 @@ test_accep_qemux86_64_bios_grub_gpt:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -557,6 +579,8 @@ test_accep_qemux86_64_bios_grub_gpt:
     paths:
       - results_accep_qemux86_64_bios_grub_gpt.xml
       - report_accep_qemux86_64_bios_grub_gpt.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_qemux86_64_bios_grub_gpt.xml
   only:
@@ -577,6 +601,8 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -585,6 +611,8 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
     paths:
       - results_accep_vexpress_qemu_uboot_uefi_grub.xml
       - report_accep_vexpress_qemu_uboot_uefi_grub.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_vexpress_qemu_uboot_uefi_grub.xml
   only:
@@ -605,6 +633,8 @@ test_accep_vexpress_qemu_flash:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -613,6 +643,8 @@ test_accep_vexpress_qemu_flash:
     paths:
       - results_accep_vexpress_qemu_flash.xml
       - report_accep_vexpress_qemu_flash.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_vexpress_qemu_flash.xml
   only:
@@ -633,6 +665,8 @@ test_accep_beagleboneblack:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -641,6 +675,8 @@ test_accep_beagleboneblack:
     paths:
       - results_accep_beagleboneblack.xml
       - report_accep_beagleboneblack.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_beagleboneblack.xml
   only:
@@ -661,6 +697,8 @@ test_accep_raspberrypi3:
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html;
       fi
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -669,6 +707,8 @@ test_accep_raspberrypi3:
     paths:
       - results_accep_raspberrypi3.xml
       - report_accep_raspberrypi3.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_accep_raspberrypi3.xml
   only:
@@ -721,6 +761,12 @@ test_backend_integration:
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
       integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
+    # sysstat monitoring suite for Alpine Linux
+    # collect cpu, load avg, memory and io usage every 2 secs forever
+    # use 'sar' from sysstat to render the result file manually
+    - apk --update --no-cache add sysstat
+    - ln -s /var/log/sa/ /var/log/sysstat
+    - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
     # Traps only work if executed in a sub shell.
     - "("
@@ -758,6 +804,8 @@ test_backend_integration:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -766,6 +814,8 @@ test_backend_integration:
     paths:
       - results_backend_integration_*.xml
       - report_backend_integration_*.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_backend_integration_*.xml
   only:
@@ -826,6 +876,12 @@ test_full_integration:
     - tar -xf stage-artifacts/host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/
     - tar -xf stage-artifacts/host-tools.tar ./mender-stress-test-client && mv mender-stress-test-client /usr/local/bin/
     - tar -xf stage-artifacts/host-tools.tar ./directory-artifact-gen && mv directory-artifact-gen /usr/local/bin/
+    # sysstat monitoring suite for Alpine Linux
+    # collect cpu, load avg, memory and io usage every 2 secs forever
+    # use 'sar' from sysstat to render the result file manually
+    - apk --update --no-cache add sysstat
+    - ln -s /var/log/sa/ /var/log/sysstat
+    - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
     # Traps only work if executed in a sub shell.
     - "("
@@ -856,6 +912,8 @@ test_full_integration:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -864,6 +922,8 @@ test_full_integration:
     paths:
       - results_full_integration.xml
       - report_full_integration.html
+      - sysstat.log
+      - sysstat.svg
     reports:
       junit: results_full_integration.xml
   only:

--- a/Documentation/how-to-debug-a-build-slave.md
+++ b/Documentation/how-to-debug-a-build-slave.md
@@ -3,30 +3,24 @@ How to debug a build slave
 
 ## Requirements
 
-Your key has to be inserted into the build slave to be able to log in. This
-needs to be done before the build slave is spawned. See example below:
+The recommended method is using Google Cloud SDK. Alternatively you can use
+the website to launch SSH sessions with the slaves.
 
-```
-SSH_KEYS='
-ssh-rsa AAAAB3NzaC1yc2...
-'
-```
+Follow the following guide to get started:
+https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
 
-Obviously this needs to be merged into the master branch before it will be used
-(or it would be very insecure). Once this is done, the next build slave that is
-launched should have your key in it.
+Important! When selecting the region/zone, you select `northamerica-northeast1-b`
 
 ## How to debug via SSH
 
 ### Preparing
 
-1. Enable STOP_SLAVE parameter when starting the build
+1. There are three phases where the Pipeline can be stoped: init, build and test.
+   Enable the correspoinding WAIT_IN_STAGE_XXX parameter when starting the build
 
 2. Unselect any platforms you don't need, because **all of them will hang after
    the job is complete**, collecting cloud fees. The job will eventually time
    out, but only after many hours.
-
-   ![Select one platform only](images/build-parameters.png)
 
    If the job you're interested in is a server-only job, select only the
    RUN_INTEGRATION_TESTS parameter.
@@ -38,93 +32,55 @@ launched should have your key in it.
 
 4. *(Optional)* If you want to interact with the slave when the normal job steps
    are done, wait until you see it looping on the `stop_slave` file in the
-   Jenkins log. Depending on the type of job, this could take a while, since it
-   only stops at the end of the job.
+   log. Depending on the type of job, this could take a while, since it only
+   stops at the end of the job.
 
 At this point you are ready to log in.
 
 
 ### Logging in
 
-1. In Jenkins, enter the correct platform label for the job.
+1. Find the stage/job you are interested in debugging. Open the console
+   log for it and find at the start something like:
+   `Running on [...] via runner-1spsyixr-gitlab-runner-slave-1573824356-780dc74d`
 
-   ![Job view](images/job-view.png)
+2. Verify you can see the same instance locally with the command
+   `gcloud compute instances list`
 
-2. Click on the "Console log".
+3. Log in via SSH to the VM with the command:
+   `gcloud compute ssh runner-1spsyixr-gitlab-runner-slave-1573824356-780dc74d`
 
-   ![Job view for label](images/job-label-view.png)
+4. Now we need to go deeper. List the running container with:
+   `sudo docker ps`
 
-3. Then click on "Full log" to get the complete console log from the job.
+5. You will get two runnig containers, one with suffix `-docker-0` and other with
+   suffix `-build-X`. The later is the one we are interested. To open a shell:
+   `sudo docker exec -it runner-1spsyiXR-project-12501706-concurrent-0-build-4 /bin/bash`
 
-   ![Partial console log](images/console.png)
+   NOTE: on integration tests jobs, that run in Alpine Linux containers, we don't
+   have `bash` so you should use `/bin/sh` instead in the above command.
 
-4. Very near the top, there is a link which goes to the host that the job is
-   executing on. Click on it.
+6. The workspace is at `/builds/Northern.tech/Mender`.
 
-   ![Full console log](images/console-full.png)
+7. (for yoctobuilds only). You need to open a new sheel as `mender` user
+   to be able to build with bitbake or run accceptance tests:
+   `sudo -u mender /bin/bash`
 
-5. On the page you get, you can see the external IP.
-
-   ![Agent and its IP address](images/agent.png)
-
-   With this you can log in using:
-
-   ```
-   ssh jenkins@<IP>
-   ```
-   Getting warnings about mismatched SSH keys is pretty common, since the
-   machines are respawning again and again and getting new SSH keys all the
-   time. Just follow the steps on the screen.
-
-6. Alternatively, if you don't see the IP, copy it from the Google Cloud Platform console. The instances page
-   maps host names to their external IPs.
-
-7. Once inside, at least for Mender jobs, the workspace is in
-   `$HOME/workspace/yoctobuild`.
-
-Keep in mind that the shell environment of your login is not the same as for the
-Jenkins job so you might want to run certain commands to populate the
-environment, or take a look at the variable dump from the Jenkins Console log
-and set some of those.
-
-Also keep in mind that the `$HOME/stop_slave` file will keep the slave online
-for a long time, but not indefinitely. Eventually the Jenkins job will time
-out. This is a safety measure to make sure a host won't hang and collect fees
-forever.
+Enjoy your debugging session.
 
 
 ### After you're done
 
-<!-- Github ignores all HTML tags we can use to add color, so use this terrible
-diff hack -->
+*IMPORTANT*: After you're done you must delete the file
+/builds/Northern.tech/Mender/mender-qa/WAIT_IN_STAGE_XXXXX, or the host will hang for
+hours, collecting cloud fees and preventing other jobs from using the slave.
 
-```diff
--Important: After you're done you must delete the $HOME/stop_slave file, or the-
--host will hang for hours, collecting cloud fees and preventing other jobs from-
--using the slave.-
-```
 
 ## Debugging with monitoring tools
-Slaves are being constantly monitored via two utilities:
+Slaves are being constantly monitored via sysstat:
 
-- [Jenkins Monitoring Plugin](https://wiki.jenkins.io/display/JENKINS/Monitoring)
 - [sysstat](https://github.com/sysstat/sysstat), specifically `sar`
 
-### Jenkins Monitoring Plugin
-The [Monitoring dashboard](https://mender-jenkins.mender.io/monitoring)  is the entrypoint
-to the plugin's reporting functonality, and displays various performance metrics of the Jenkins master server.
-It's what you'd typically expect: cpu usage, mem usage, top-like OS-processes view, etc. It's just best
-to poke around and see what's available.
-
-A more interesting view can be accessed at `https://mender-jenkins.mender.io/monitoring/nodes`. This dashboard
-aggregates stats pertaining to all slave nodes launched by Jenkins and gives some insight into individual nodes.
-
-You can access individual nodes' dashboard at `https://mender-jenkins.mender.io/monitoring/nodes/<node_name>`.
-Note that the graphs here still refer to the combined capacity of the whole slave farm; everything else is per-node though.
-
-One major gotcha with the plugin is that it doesn't persist any slave data. You can observe reports on the fly,
-but as soon as GCP kills the slave, the stats are gone too. That's not useful for a post-mortem analysis, and `sysstat` is the
-better option.
 
 ### sysstat
 The `sar` utility is started in the init script; it collects:
@@ -137,9 +93,22 @@ over the whole lifetime of the slave (interval: 2 secs).
 
 The output file is at `/var/log/sysstat/sysstat.log`.
 
-For post mortem analysis, grab the file e.g. via scp:
+For post mortem analysis, you can find the raw sysstat.log file
+and a processed sysstat.svg file in the Artifacts section of
+each build and test job.
 
-`scp jenkins@host:/var/log/sysstat/sysstat.log <your_file_path>`
+However, if you need to retreive it while running or in a
+situation where the job does not complete, you need to grab
+the file via scp:
+
+TODO: how to make this in a nice command? docker + scp
+```
+gcloud compute ssh <build-slave>`
+sudo docker cp <container_id>:/var/log/sysstat/sysstat.log .
+exit
+gcloud compute scp <build-slave>:sysstat.log .`
+```
+
 
 This file can be processed and reviewed by sysstat's `sadf` utility. The simplest operation
 is to dump all charts to svg:
@@ -153,8 +122,6 @@ See `man sadf` for othe tips (exporting to other formats, slicing by time and me
 ## Tips and tricks
 
 * You can enable the STOP_SLAVE functionality even if you didn't enable it in
-  the build parameters. Just log in after the build steps and create the
-  `$HOME/stop_slave` file while the build is still running. Note that if you try
-  to log in before the build steps have started, you may either not be able to,
-  or the build will delete your `stop_slave` file before it has the chance to
-  have its effect.
+  the build parameters. Just log in after the build steps, jump into the container,
+  and create `/builds/Northern.tech/Mender/mender-qaWAIT_IN_STAGE_BUILD` (or _INIT,
+  or TEST) while the build is still running.


### PR DESCRIPTION
```
commit b67fd2846f058283b4b6a9206e5ee257c1a401e1
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Nov 15 14:05:59 2019 +0100

    Install and enable sysstat monitoring suite for integration tests jobs
    
    Both integration and backend-tests jobs are Alpine Linux based, so the
    install and setup is slightly different.

commit 5ef835fc90235b9755e494f6bdeb2bf27eeb384f
Author: Lluis Campos <lluis.campos@northern.tech>
Date:   Fri Nov 15 14:07:09 2019 +0100

    Use highcpu/highmem tags to differentiate yocto builds from integ tests
    
    Yocto builds are CPU hungry, while integration tests seem to be short in
    memory.
    
    By using two different tags (and two different master runners) we can
    better control the requirements for the two different cases and the
    overall cost of the infrastructure.
```