### PR TITLE
Add docker network monitoring

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -736,7 +736,6 @@ test_backend_integration:
       libc-dev libffi-dev openssl-dev python3 curl
     - pip install docker-compose==1.24.0
     - pip3 install pyyaml
-    - rm -rf /var/cache/apk/*
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -835,12 +834,12 @@ test_full_integration:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
 
+    # Start up docker
     - /usr/local/bin/dockerd-entrypoint.sh &
     - sleep 10
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
 
-    - rm -rf /var/cache/apk/*
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -872,6 +871,7 @@ test_full_integration:
     # Other dependencies
     - tar -xf stage-artifacts/host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/
     - tar -xf stage-artifacts/host-tools.tar ./directory-artifact-gen && mv directory-artifact-gen /usr/local/bin/
+
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -878,6 +878,10 @@ test_full_integration:
     - apk --update --no-cache add sysstat
     - ln -s /var/log/sa/ /var/log/sysstat
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
+
+    # docker-watcher tool for Docker network monitoring
+    - apk --update --no-cache add tcpdump
+    - git clone https://github.com/lluiscampos/docker-watcher.git /docker-watcher
   script:
     # Traps only work if executed in a sub shell.
     - "("
@@ -897,6 +901,9 @@ test_full_integration:
       esac fi
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - cd integration/tests
+
+    # Start Docker network monitoring just before the tests
+    - /docker-watcher/docker-watcher.sh -r yes -t 5 -d 5 -o ${CI_PROJECT_DIR}/docker-watcher-pcap- --no-color >${CI_PROJECT_DIR}/docker-watcher.log 2>&1 &
     - ./run.sh --no-download --machine-name qemux86-64
 
     # Always keep this at the end of the script stage
@@ -910,6 +917,8 @@ test_full_integration:
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
+    - pkill docker-watcher || true
+    - tar -czf docker-watcher-pcap.tar.gz docker-watcher-pcap-*
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
   artifacts:
@@ -920,6 +929,8 @@ test_full_integration:
       - report_full_integration.html
       - sysstat.log
       - sysstat.svg
+      - docker-watcher-pcap.tar.gz
+      - docker-watcher.log
     reports:
       junit: results_full_integration.xml
   only:


### PR DESCRIPTION
Add docker-watcher tool in integration tests job
    
So that we can monitor the full Docker network and hopefully ease
debugging of the issues.