### PR TITLE
QA-106: Publish release from GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -468,6 +468,8 @@ test_accep_qemux86_64_uefi_grub:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
     - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html;
@@ -480,6 +482,7 @@ test_accep_qemux86_64_uefi_grub:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_qemux86_64_uefi_grub.xml
       - report_accep_qemux86_64_uefi_grub.html
       - sysstat.log
@@ -487,9 +490,10 @@ test_accep_qemux86_64_uefi_grub:
     reports:
       junit: results_accep_qemux86_64_uefi_grub.xml
   only:
-    # The build for this configuration is done unconditionally in build_client job,
-    # so run corresponding test job only if TEST_QEMUX86_64_UEFI_GRUB is set
+    # Even though the build for this configuration is done unconditionally in build_client job,
+    # we will still trigger this one for BUILD_QEMUX86_64_UEFI_GRUB to be able to collect artifacts
     variables:
+      - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
       - $TEST_QEMUX86_64_UEFI_GRUB == "true"
 
 test_accep_vexpress_qemu:
@@ -501,6 +505,8 @@ test_accep_vexpress_qemu:
     JOB_BASE_NAME: mender_vexpress_qemu
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/vexpress-qemu/vexpress-qemu_release_1_*.mender stage-artifacts/
     - if [ "$TEST_VEXPRESS_QEMU" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html;
@@ -513,6 +519,7 @@ test_accep_vexpress_qemu:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_vexpress_qemu.xml
       - report_accep_vexpress_qemu.html
       - sysstat.log
@@ -533,6 +540,8 @@ test_accep_qemux86_64_bios_grub:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-bios-grub/qemux86-64-bios-grub_release_1_*.mender stage-artifacts/
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html;
@@ -545,6 +554,7 @@ test_accep_qemux86_64_bios_grub:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_qemux86_64_bios_grub.xml
       - report_accep_qemux86_64_bios_grub.html
       - sysstat.log
@@ -565,6 +575,8 @@ test_accep_qemux86_64_bios_grub_gpt:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-bios-grub-gpt/qemux86-64-bios-grub-gpt_release_1_*.mender stage-artifacts/
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB_GPT" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html;
@@ -577,6 +589,7 @@ test_accep_qemux86_64_bios_grub_gpt:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_qemux86_64_bios_grub_gpt.xml
       - report_accep_qemux86_64_bios_grub_gpt.html
       - sysstat.log
@@ -597,6 +610,8 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/vexpress-qemu-uboot-uefi-grub/vexpress-qemu-uboot-uefi-grub_release_1_*.mender stage-artifacts/
     - if [ "$TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html;
@@ -609,6 +624,7 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_vexpress_qemu_uboot_uefi_grub.xml
       - report_accep_vexpress_qemu_uboot_uefi_grub.html
       - sysstat.log
@@ -620,6 +636,9 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
       - $BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
       - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
 
+# Note that vexpress-qemu-flash yoctobuild does not generate a ext4 image so
+# the build script does not generate the Mender Artifact neither.
+# Therefore this job has no deliverables to be passed to the release stage.
 test_accep_vexpress_qemu_flash:
   stage: test
   dependencies:
@@ -661,6 +680,9 @@ test_accep_beagleboneblack:
     JOB_BASE_NAME: mender_beagleboneblack
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/beagleboneblack/beagleboneblack_release_1_*.mender stage-artifacts/
+    - cp $WORKSPACE/beagleboneblack/mender-beagleboneblack_*.sdimg.gz stage-artifacts/
     - if [ "$TEST_BEAGLEBONEBLACK" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html;
@@ -673,6 +695,7 @@ test_accep_beagleboneblack:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_beagleboneblack.xml
       - report_accep_beagleboneblack.html
       - sysstat.log
@@ -693,6 +716,9 @@ test_accep_raspberrypi3:
     JOB_BASE_NAME: mender_raspberrypi3
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/raspberrypi3/raspberrypi3_release_1_*.mender stage-artifacts/
+    - cp $WORKSPACE/raspberrypi3/mender-raspberrypi3_*.sdimg.gz stage-artifacts/
     - if [ "$TEST_RASPBERRYPI3" = "true" ]; then
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml;
         cp ${CI_PROJECT_DIR}/../meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html;
@@ -705,6 +731,7 @@ test_accep_raspberrypi3:
     expire_in: 2w
     when: always
     paths:
+      - stage-artifacts/
       - results_accep_raspberrypi3.xml
       - report_accep_raspberrypi3.html
       - sysstat.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -848,6 +848,7 @@ test_backend_integration:
       - $RUN_INTEGRATION_TESTS == "true"
 
 test_full_integration:
+  allow_failure: true
   stage: test
   image: docker:18-dind
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -951,7 +951,7 @@ test_full_integration:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
 
-release_docker:
+release_docker_images:
   when: manual
   stage: release
   image: teracy/ubuntu:18.04-dind-18.09.9
@@ -990,7 +990,7 @@ release_docker:
         docker push $docker_url:${version};
       done
 
-release_s3:
+release_board_artifacts:
   when: manual
   stage: release
   image: debian:buster
@@ -1033,4 +1033,127 @@ release_s3:
           aws s3api put-object-acl --acl public-read --bucket mender
             --key ${client_version}/${board_name}/mender-${board_name}_${client_version}.sdimg.gz;
         fi;
+      done
+
+build_mender-cli:
+  stage: build
+  image: golang:1.11.4
+  tags:
+    - mender-qa-slave
+  dependencies:
+    - init_workspace
+  before_script:
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env .
+    # Export GOPATH
+    - export GOPATH="$WORKSPACE/go"
+    # cd into component path
+    - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-cli
+  script:
+    - if grep -q build-multiplatform Makefile; then
+        make build-multiplatform;
+      else
+        make build;
+      fi
+    - cp mender-cli* $CI_PROJECT_DIR/
+  artifacts:
+    paths:
+      - mender-cli*
+
+build_mender-artifact:
+  stage: build
+  image: docker
+  services:
+    - docker:dind
+  tags:
+    - mender-qa-slave
+  dependencies:
+    - init_workspace
+  before_script:
+    # Check correct dind setup
+    - docker version
+    # Install dependencies
+    - apk add --no-cache make
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env .
+    # cd into component path
+    - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-artifact
+  stage: build
+  script:
+    - make build-natives-contained
+    - cp mender-artifact-* $CI_PROJECT_DIR/
+  artifacts:
+    expire_in: 2w
+    paths:
+      - mender-artifact-*
+  tags:
+    - docker
+
+release_binary_tools:
+  when: manual
+  stage: release
+  image: debian:buster
+  dependencies:
+    - init_workspace
+    - build_mender-cli
+    - build_mender-artifact
+  before_script:
+    # Install dependencies
+    - apt update && apt install -yyq awscli git python3 python3-pip
+    - pip3 install --upgrade pyyaml
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env /tmp
+    - mv mender-cli* mender-artifact-* /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env .
+    - mv /tmp/mender-cli* /tmp/mender-artifact-* .
+  script:
+    # mender-cli
+    - mender_cli_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-cli --in-integration-version HEAD)
+    - echo "=== mender-cli $mender_cli_version ==="
+    # We can simplify once mender-cli 1.2.0 is not supported
+    - if grep -q build-multiplatform $WORKSPACE/go/src/github.com/mendersoftware/mender-cli/Makefile; then
+        echo "Publishing ${mender_cli_version} version for linux to S3";
+        aws s3 cp mender-cli.linux.amd64
+          s3://mender/mender-cli/${mender_cli_version}/linux/mender-cli;
+        aws s3api put-object-acl --acl public-read --bucket mender
+          --key mender-cli/${mender_cli_version}/linux/mender-cli;
+        echo "Publishing ${mender_cli_version} version for darwin to S3";
+        aws s3 cp mender-cli.darwin.amd64
+          s3://mender/mender-cli/${mender_cli_version}/darwin/mender-cli;
+        aws s3api put-object-acl --acl public-read --bucket mender
+          --key mender-cli/${mender_cli_version}/darwin/mender-cli;
+      else
+        aws s3 cp mender-cli
+          s3://mender/mender-cli/${mender_cli_version}/mender-cli;
+        aws s3api put-object-acl --acl public-read --bucket mender
+          --key mender-cli/${mender_cli_version}/mender-cli;
+      fi
+    # mender-artifact
+    - mender_artifact_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-artifact --in-integration-version HEAD)
+    - echo "=== mender-artifact $mender_artifact_version ==="
+    - for bin in mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe; do
+        platform=${bin#mender-artifact-};
+        platform=${platform%.*};
+        echo "Publishing ${mender_artifact_version} version for ${platform} to S3";
+        aws s3 cp ${bin}
+          s3://mender/mender-artifact/${mender_artifact_version}/${platform}/mender-artifact;
+        aws s3api put-object-acl --acl public-read --bucket mender
+          --key mender-artifact/${mender_artifact_version}/${platform}/mender-artifact;
       done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,7 @@ stages:
   - init
   - build
   - test
+  - release
 
 init_workspace:
   stage: init
@@ -952,3 +953,87 @@ test_full_integration:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
+
+release_docker:
+  when: manual
+  stage: release
+  image: teracy/ubuntu:18.04-dind-18.09.9
+  services:
+    - docker:18-dind
+  tags:
+    - mender-qa-slave
+  dependencies:
+    - init_workspace
+    - build_servers
+    - build_client
+  before_script:
+    # Check correct dind setup
+    - docker version
+    # Install dependencies
+    - apt update && apt install -yyq git python3 python3-pip
+    - pip3 install --upgrade pyyaml
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env /tmp/stage-artifacts .
+    # Login for private repos
+    - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+    - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
+  script:
+    # Load, tag and push Docker images
+    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker); do
+        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD);
+        docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
+        docker load -i stage-artifacts/${image}.tar;
+        docker tag $docker_url:pr $docker_url:${version};
+        docker push $docker_url:${version};
+      done
+
+release_s3:
+  when: manual
+  stage: release
+  image: debian:buster
+  tags:
+    - mender-qa-slave
+  dependencies:
+    - init_workspace
+    - test_accep_qemux86_64_uefi_grub
+    - test_accep_vexpress_qemu
+    - test_accep_qemux86_64_bios_grub
+    - test_accep_qemux86_64_bios_grub_gpt
+    - test_accep_vexpress_qemu_uboot_uefi_grub
+    - test_accep_vexpress_qemu_flash
+    - test_accep_beagleboneblack
+    - test_accep_raspberrypi3
+  before_script:
+    # Install dependencies
+    - apt update && apt install -yyq awscli git python3 python3-pip
+    - pip3 install --upgrade pyyaml
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env /tmp/stage-artifacts .
+  script:
+    # Publish boards artifacts and sdimg (when hw). Note that vexpress-qemu-flash is ignored
+    - client_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender --in-integration-version HEAD)
+    - for board_name in qemux86-64-uefi-grub vexpress-qemu qemux86-64-bios-grub-gpt qemux86-64-bios-grub
+      vexpress-qemu-uboot-uefi-grub beagleboneblack raspberrypi3; do
+        aws s3 cp stage-artifacts/${board_name}_release_1_${client_version}.mender
+          s3://mender/${client_version}/${board_name}/${board_name}_release_1_${client_version}.mender;
+        aws s3api put-object-acl --acl public-read --bucket mender
+          --key ${client_version}/${board_name}/${board_name}_release_1_${client_version}.mender;
+        if ! echo $board_name | grep -q qemu; then
+          aws s3 cp stage-artifacts/mender-${board_name}_${client_version}.sdimg.gz
+            s3://mender/${client_version}/${board_name}/mender-${board_name}_${client_version}.sdimg.gz;
+          aws s3api put-object-acl --acl public-read --bucket mender
+            --key ${client_version}/${board_name}/mender-${board_name}_${client_version}.sdimg.gz;
+        fi;
+      done

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -435,9 +435,6 @@ build_servers:
   variables:
     JOB_BASE_NAME: mender_servers
     ONLY_BUILD: "true"
-  only:
-    variables:
-      - $RUN_INTEGRATION_TESTS == "true"
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mkdir -p stage-artifacts


### PR DESCRIPTION
Introduces a new stage "release" in mender-qa Pipeline to publish the different release deliverables: Docker images, yocto boards Artifacts, and mender-cli/mender-client binaries.

This branch will be used for 2.1.1 and 2.2.1 releases starting tomorrow. A follow-up PR with a clean-up and a refactor of the yoctobuild script will be done after the releases.

Better reviewed commit by commit.