### PR TITLE
Fix mender-binary-delta selection pick

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -459,7 +459,7 @@ fi
 # -----------------------
 
 if [ -d $WORKSPACE/meta-mender/meta-mender-commercial ]; then
-    RECIPE=$(ls $WORKSPACE/meta-mender/meta-mender-commercial/recipes-mender/mender-binary-delta | sort | head -n1)
+    RECIPE=$(ls $WORKSPACE/meta-mender/meta-mender-commercial/recipes-mender/mender-binary-delta | sort | tail -n1)
     mkdir -p $WORKSPACE/mender-binary-delta
     s3cmd get --recursive s3://$(sed -e 's,delta_,delta/,; s/\.bb$//' <<<$RECIPE)/ $WORKSPACE/mender-binary-delta/
 fi


### PR DESCRIPTION
Fix mender-binary-delta selection pick, so that if there is more than one, download the binaries for the latest.