### PR TITLE
Add logs from backend integration tests to artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -820,6 +820,10 @@ test_backend_integration:
       PYTEST_ARGS="-k 'not Multitenant'" ./run;
       fi
 
+    - ls /tmp/acceptance.* > /tmp/acceptance.log.names 2>/dev/null
+    - find /tmp -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec gzip -2 "{}" \;
+    - mkdir ${CI_PROJECT_DIR}/backend_logs
+    - mv /tmp/acceptance.* ${CI_PROJECT_DIR}/backend_logs/
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
 
@@ -830,6 +834,7 @@ test_backend_integration:
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
     - cp /var/log/sysstat/sysstat.log .
+    - mv ${CI_PROJECT_DIR}/backend_logs/* .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
@@ -841,6 +846,7 @@ test_backend_integration:
       - report_backend_integration_*.html
       - sysstat.log
       - sysstat.svg
+      - acceptance.*.gz
     reports:
       junit: results_backend_integration_*.xml
 


### PR DESCRIPTION
Save backend integration tests logs in artifacts in gitlab.
