### PR TITLE
Update GitHub authentication to Personal Access Token

### DIFF
--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -71,7 +71,7 @@ for key in $(compgen -A export); do
     fi
     pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
 
-    curl -iv --user "$GITHUB_BOT_USER:$GITHUB_BOT_PASSWORD" \
+    curl -iv -H "Authorization: bearer $GITHUB_BOT_TOKEN" \
          -d "$request_body" \
          "$pr_status_endpoint"
 done


### PR DESCRIPTION
Update GitHub authentication to Personal Access Token

As the user/pass method will soon be deprecated.