### PR TITLE
POC: Generate tests reports with Allure framework

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ variables:
   TEST_RASPBERRYPI3: "false"
   RUN_INTEGRATION_TESTS: "true"
   SPECIFIC_INTEGRATION_TEST: ""
-  TESTS_IN_PARALLEL: "2"
+  TESTS_IN_PARALLEL: "4"
   PUBLISH_ARTIFACTS: "false"
   WAIT_IN_STAGE_INIT: ""
   WAIT_IN_STAGE_BUILD: ""
@@ -942,6 +942,9 @@ test_full_integration:
     - pip install  -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
     - pip3 install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
+    # PoC: allure reporting
+    - pip install allure-pytest
+
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
@@ -984,7 +987,7 @@ test_full_integration:
       esac fi
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - cd integration/tests
-    - ./run.sh --no-download --machine-name qemux86-64
+    - ./run.sh --no-download --machine-name qemux86-64 -- --alluredir=allure-results
 
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
@@ -998,6 +1001,7 @@ test_full_integration:
     - cp -r ${CI_PROJECT_DIR}/../integration/tests/mender_test_logs .
     - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
     - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
+    - tar -czf allure-results.tar.gz -C ${CI_PROJECT_DIR}/../integration/tests/allure-results/ .
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -1011,6 +1015,7 @@ test_full_integration:
       - mender_test_logs
       - results_full_integration.xml
       - report_full_integration.html
+      - allure-results.tar.gz
       - sysstat.log
       - sysstat.svg
     reports:

--- a/scripts/allure-test-reports/Dockerfile
+++ b/scripts/allure-test-reports/Dockerfile
@@ -1,0 +1,11 @@
+FROM java:latest
+
+RUN wget https://dl.bintray.com/qameta/maven/io/qameta/allure/allure-commandline/2.13.1/allure-commandline-2.13.1.zip && \
+    unzip allure-commandline-2.13.1.zip && \
+    rm allure-commandline-2.13.1.zip
+
+RUN ln -s /allure-2.13.1/bin/allure /usr/bin/allure
+
+COPY entrypoint.sh /
+
+ENTRYPOINT "/entrypoint.sh"

--- a/scripts/allure-test-reports/Dockerfile.serve
+++ b/scripts/allure-test-reports/Dockerfile.serve
@@ -1,0 +1,4 @@
+FROM nginx:alpine
+
+ARG REPORT
+COPY $REPORT /usr/share/nginx/html/

--- a/scripts/allure-test-reports/docker-allure-report-generate
+++ b/scripts/allure-test-reports/docker-allure-report-generate
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright 2019 Northern.tech AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+
+function usage() {
+    echo "./$(basename $0) <prev-report> <results> <output-report>"
+    echo "  where <prev-report> is the last generated report,"
+    echo "  <results> is the current test results,"
+    echo "  and <output-report> is where to copy the new report"
+    echo "  Set <prev-report> to /dev/null for the very first report."
+}
+
+if [ -z "$3" ]; then
+    usage
+    exit 1
+fi
+
+PREV_REPORT=$1
+RESULTS=$2
+NEW_REPORT=$3
+
+IMAGE_NAME_GENERATE=allure-report-generator
+
+docker build -t ${IMAGE_NAME_GENERATE} .
+
+mkdir -p $NEW_REPORT
+
+docker run \
+       --volume "$(realpath $PREV_REPORT):/prev-report" \
+       --volume "$(realpath $RESULTS):/results" \
+       --volume "$(realpath $NEW_REPORT):/report" \
+       $IMAGE_NAME_GENERATE
+
+sudo chown -R $(id -u):$(id -g) $NEW_REPORT
+
+echo "Test report generated at $NEW_REPORT"

--- a/scripts/allure-test-reports/docker-allure-report-serve
+++ b/scripts/allure-test-reports/docker-allure-report-serve
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2019 Northern.tech AS
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+
+function usage() {
+    echo "./$(basename $0) <report>"
+    echo "  where <report> is the directory containing the test report."
+}
+
+if [ -z "$1" ]; then
+    usage
+    exit 1
+fi
+
+REPORT=$1
+
+IMAGE_NAME_SERVE=allure-report-server
+
+docker build -t ${IMAGE_NAME_SERVE} --build-arg REPORT=$REPORT -f Dockerfile.serve .
+
+echo "Serving website in localhost:80"
+docker run \
+       --network host \
+       $IMAGE_NAME_SERVE

--- a/scripts/allure-test-reports/entrypoint.sh
+++ b/scripts/allure-test-reports/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+PREV_REPORT=/prev-report
+RESULTS=/results
+NEW_REPORT=/report
+
+if [ -d $PREV_REPORT/history ]; then
+  cp -r $PREV_REPORT/history $RESULTS
+else
+  echo "WARNING: No history found in previous report"
+fi
+
+allure generate $RESULTS
+
+cp -r /allure-report/* $NEW_REPORT


### PR DESCRIPTION
The main feature we want to showcase is having the "history" of failing
tests. This framework supports it in a rather limited way, but let's
give it a try...

Still a PoC that requires manual work to generate the actual reports; to
merge it we need logic to generate the reports from the Pipeline (on
nightly builds) and upload them to an S3 bucket.