### PR TITLE
Perform commits check only for mender-qa PRs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -59,8 +59,10 @@ variables:
 # Check signoffs in commits
 include:
     - project: 'Northern.tech/Mender/mendertesting'
-      ref: master
       file: '.gitlab-ci-check-commits-signoffs.yml'
+      only:
+        variables:
+          - $MENDER_QA_REV != "master"
 
 stages:
   - init


### PR DESCRIPTION
In other words: skip the check for any build running mender-qa master
(which is the vast majority of times).

This will save precious GitLab CI minutes, which for mender-qa have
considerably increased during this month.