### PR TITLE
Build client unconditionally

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -412,10 +412,6 @@ init_workspace:
     - ")"
 
 build_client:
-  only:
-    variables:
-      - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
-      - $RUN_INTEGRATION_TESTS == "true"
   stage: build
   dependencies:
     - init_workspace


### PR DESCRIPTION
So that we can for example build/publish a release candidate with no
testing (use case for consecutive builds during release procedure).