### PR TITLE
Use shared runners lightweight jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -472,10 +472,11 @@ build_servers:
 
     - mkdir -p stage-artifacts
     - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
-      if ! echo $repo | grep -q mender-client-qemu; then
-      docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
-      docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
-      fi; done
+        if ! echo $repo | grep -q mender-client-qemu; then
+          docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
+          docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
+        fi;
+      done
     # Tarball with mender-cli, mender-artifact, mender-stress-test-client and Artifact generation scripts
     - tar -cf stage-artifacts/host-tools.tar -C ../go/bin/ .
     - cp /var/log/sysstat/sysstat.log .
@@ -848,15 +849,16 @@ test_backend_integration:
 
     # Load all docker images except client
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      if ! echo $repo | grep -q mender-client-qemu; then
-      docker load -i stage-artifacts/${repo}.tar;
-      fi; done
+        if ! echo $repo | grep -q mender-client-qemu; then
+          docker load -i stage-artifacts/${repo}.tar;
+        fi;
+      done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      integration/extra/release_tool.py --set-version-of $repo --version pr;
+        integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
@@ -882,14 +884,27 @@ test_backend_integration:
 
     # for older releases, ignore test suite selection and just run open tests
     - if [ -f ../docker-compose.enterprise.yml ]; then
-      case $INTEGRATION_TEST_SUITE in
-      "enterprise") PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run -f=../docker-compose.enterprise.yml -f=../docker-compose.storage.minio.yml -f=../extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml -f=../extra/smtp-testing/conductor-workers-smtp-test.yml -f=../extra/stripe-testing/stripe-test.docker-compose.yml ;;
-      "open") PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;;
-      *) PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;
-      PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run -f=../docker-compose.enterprise.yml -f=../docker-compose.storage.minio.yml -f=../extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml -f=../extra/smtp-testing/conductor-workers-smtp-test.yml -f=../extra/stripe-testing/stripe-test.docker-compose.yml ;;
-      esac
+        case $INTEGRATION_TEST_SUITE in
+          "open")
+            PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;;
+          "enterprise")
+            PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run
+                -f=../docker-compose.enterprise.yml
+                -f=../docker-compose.storage.minio.yml
+                -f=../extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
+                -f=../extra/smtp-testing/conductor-workers-smtp-test.yml
+                -f=../extra/stripe-testing/stripe-test.docker-compose.yml ;;
+          *)
+            PYTEST_ARGS="$PYTEST_ARGS_REPORT_OPEN -k 'not Enterprise and not Multitenant'" ./run ;
+            PYTEST_ARGS="$PYTEST_ARGS_REPORT_ENTERPRISE -k Enterprise" ./run
+                -f=../docker-compose.enterprise.yml
+                -f=../docker-compose.storage.minio.yml
+                -f=../extra/recaptcha-testing/tenantadm-test-recaptcha-conf.yml
+                -f=../extra/smtp-testing/conductor-workers-smtp-test.yml
+                -f=../extra/stripe-testing/stripe-test.docker-compose.yml ;;
+        esac
       else
-      PYTEST_ARGS="-k 'not Multitenant'" ./run;
+        PYTEST_ARGS="-k 'not Multitenant'" ./run;
       fi
 
     # Always keep this at the end of the script stage
@@ -966,14 +981,14 @@ test_full_integration:
 
     # Load all docker images
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      docker load -i stage-artifacts/${repo}.tar;
+        docker load -i stage-artifacts/${repo}.tar;
       done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for repo in `integration/extra/release_tool.py -l docker -a`; do
-      integration/extra/release_tool.py --set-version-of $repo --version pr;
+        integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
     # Other dependencies
     - tar -xf stage-artifacts/host-tools.tar ./mender-artifact && mv mender-artifact /usr/local/bin/
@@ -997,10 +1012,13 @@ test_full_integration:
     # only do automatic test suite selection if the user wasn't specific
     # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
     - if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
-      case $INTEGRATION_TEST_SUITE in
-      "enterprise") export SPECIFIC_INTEGRATION_TEST="Enterprise";;
-      "open") export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
-      esac fi
+        case $INTEGRATION_TEST_SUITE in
+          "enterprise")
+            export SPECIFIC_INTEGRATION_TEST="Enterprise";;
+          "open")
+            export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
+        esac
+      fi
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - cd integration/tests
     - ./run.sh --no-download --machine-name qemux86-64

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,8 +72,6 @@ stages:
 init_workspace:
   stage: init
   image: alpine:latest
-  tags:
-    - mender-qa-slave
   script:
     # Traps only work if executed in a sub shell.
     - "("
@@ -1056,11 +1054,9 @@ test_full_integration:
 release_docker_images:
   when: manual
   stage: release
-  image: teracy/ubuntu:18.04-dind-18.09.9
+  image: docker
   services:
-    - docker:18-dind
-  tags:
-    - mender-qa-slave
+    - docker:19.03.5-dind
   dependencies:
     - init_workspace
     - build_servers
@@ -1096,8 +1092,6 @@ release_board_artifacts:
   when: manual
   stage: release
   image: debian:buster
-  tags:
-    - mender-qa-slave
   dependencies:
     - init_workspace
     - test_accep_qemux86_64_uefi_grub
@@ -1140,8 +1134,6 @@ release_board_artifacts:
 build_mender-cli:
   stage: build
   image: golang:1.11.4
-  tags:
-    - mender-qa-slave
   dependencies:
     - init_workspace
   before_script:
@@ -1190,7 +1182,7 @@ build_mender-artifact:
   services:
     - docker:dind
   tags:
-    - mender-qa-slave
+    - docker
   dependencies:
     - init_workspace
   before_script:
@@ -1231,8 +1223,6 @@ build_mender-artifact:
     expire_in: 2w
     paths:
       - mender-artifact-*
-  tags:
-    - docker
 
 release_binary_tools:
   when: manual


### PR DESCRIPTION
Use shared runners for all lightweight jobs

Job build_mender-artiafct was overriding tags so in effect was using
shared runners.

Clean this up and once we are on it, utilize shared runners for easy
tasks in mender-qa pipeline. This will use GitLab CI minutes quota but
save GCP minutes, which we think it will save money.