### PR TITLE
Amend backend-tests log collection adding a file exit guard

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -893,7 +893,9 @@ test_backend_integration:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-    - ls ${CI_PROJECT_DIR}/../integration/backend-tests/acceptance.* | xargs -n 1 -i cp {} .
+    - if [ -f ${CI_PROJECT_DIR}/../integration/backend-tests/acceptance.* ]; then
+        ls ${CI_PROJECT_DIR}/../integration/backend-tests/acceptance.* | xargs -n 1 -i cp {} .;
+      fi
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
     - cp /var/log/sysstat/sysstat.log .


### PR DESCRIPTION
The file only exists on failures.