### PR TITLE
Renamed mender -> mender-client

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -148,7 +148,11 @@ EOF
 
     # Assuming sumo or newer
     cat >> $BUILDDIR/conf/local.conf <<EOF
+# MEN-2948: Renamed mender recipe -> mender-client
+# But the `mender` reference has to be kept for backwards compatibility
+# with 2.1.x, 2.2.x, and 2.3.x
 EXTERNALSRC_pn-mender = "$WORKSPACE/go"
+EXTERNALSRC_pn-mender-client = "$WORKSPACE/go"
 EXTERNALSRC_pn-mender-artifact = "$WORKSPACE/go"
 EXTERNALSRC_pn-mender-artifact-native = "$WORKSPACE/go"
 EOF
@@ -183,11 +187,19 @@ EOF
     # influence which version Yocto and the binaries will show.
     if [ -n "$mender_on_exact_tag" ]; then
         cat >> $BUILDDIR/conf/local.conf <<EOF
+# MEN-2948: Renamed mender recipe -> mender-client
+# But the `mender` reference has to be kept for backwards compatibility
+# with 2.1.x, 2.2.x, and 2.3.x
 PREFERRED_VERSION_pn-mender = "$mender_on_exact_tag"
+PREFERRED_VERSION_pn-mender-client = "$mender_on_exact_tag"
 EOF
     else
         cat >> $BUILDDIR/conf/local.conf <<EOF
+# MEN-2948: Renamed mender recipe -> mender-client
+# But the `mender` reference has to be kept for backwards compatibility
+# with 2.1.x, 2.2.x, and 2.3.x
 PREFERRED_VERSION_pn-mender = "$client_version-git%"
+PREFERRED_VERSION_pn-mender-client= "$client_version-git%"
 EOF
     fi
 


### PR DESCRIPTION
This means that the variables referencing the recipe also has to be renamed, in
order for this to build properly.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>