### PR TITLE
Remove the -a option from the release_tool.py docker commands

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -469,7 +469,7 @@ build_servers:
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - mkdir -p stage-artifacts
-    - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker -a`; do
+    - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker`; do
         if ! echo $repo | grep -q mender-client-qemu; then
           docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
           docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
@@ -846,7 +846,7 @@ test_backend_integration:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images except client
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+    - for repo in `integration/extra/release_tool.py -l docker`; do
         if ! echo $repo | grep -q mender-client-qemu; then
           docker load -i stage-artifacts/${repo}.tar;
         fi;
@@ -855,7 +855,7 @@ test_backend_integration:
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+    - for repo in `integration/extra/release_tool.py -l docker`; do
         integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
     # sysstat monitoring suite for Alpine Linux
@@ -978,14 +978,14 @@ test_full_integration:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+    - for repo in `integration/extra/release_tool.py -l docker`; do
         docker load -i stage-artifacts/${repo}.tar;
       done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
-    - for repo in `integration/extra/release_tool.py -l docker -a`; do
+    - for repo in `integration/extra/release_tool.py -l docker`; do
         integration/extra/release_tool.py --set-version-of $repo --version pr;
       done
     # Other dependencies

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -277,7 +277,7 @@ export GOPATH="$WORKSPACE/go"
 
 if grep mender_servers <<<"$JOB_BASE_NAME"; then
     # Use release tool to query for available docker names.
-    for docker in $($WORKSPACE/integration/extra/release_tool.py --list docker -a ); do (
+    for docker in $($WORKSPACE/integration/extra/release_tool.py --list docker ); do (
 
         git=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker git)
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
@@ -366,7 +366,7 @@ if grep mender_servers <<<"$JOB_BASE_NAME"; then
     ); done
 
     # Builds that don't use Docker
-    for git in $($WORKSPACE/integration/extra/release_tool.py --list git -a ); do (
+    for git in $($WORKSPACE/integration/extra/release_tool.py --list git ); do (
         case "$git" in
             mender-cli)
                 cd $WORKSPACE/go/src/github.com/mendersoftware/$git


### PR DESCRIPTION
The -a option lists all the docker contains, including the non-releasable
ones. This leads to pipeline errors now that we are disabling conductor
and its dependencies and workers.