### PR TITLE
QA-143: Create new job in Pipeline only for client Docker publish

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,6 +51,7 @@ variables:
   WAIT_IN_STAGE_BUILD: ""
   WAIT_IN_STAGE_TEST: ""
   CLEAN_BUILD_CACHE: ""
+  PUBLISH_DOCKER_CLIENT_IMAGES: "false"
 
   # Internal address for nfs sstate cache server (northamerica-northeast1-b)
   SSTATE_CACHE_INTRNL_ADDR: 10.162.0.2
@@ -1050,6 +1051,47 @@ test_full_integration:
       - sysstat.svg
     reports:
       junit: results_full_integration.xml
+
+# This job allows mender repo to publish the related Docker client images on
+# merges to master or release branches.
+# Do not confuse with release_docker_images which publishes all images
+# (including client ones) used during releases.
+publish_docker_client_images:
+  only:
+    variables:
+      - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"
+  stage: release
+  image: docker
+  services:
+    - docker:19.03.5-dind
+  dependencies:
+    - init_workspace
+    - build_client
+  before_script:
+    # Check correct dind setup
+    - docker version
+    # Install dependencies
+    - apk add git python3 py3-pip
+    - pip3 install --upgrade pyyaml
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env /tmp/stage-artifacts .
+    # Login for private repos
+    - docker login -u menderbuildsystem -p ${DOCKER_PASSWORD}
+  script:
+    # Load, tag and push mender-client-docker, mender-client-qemu, mender-client-qemu-rofs
+    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | grep mender-client); do
+        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image --in-integration-version HEAD);
+        docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
+        docker load -i stage-artifacts/${image}.tar;
+        docker tag $docker_url:pr $docker_url:${version};
+        docker push $docker_url:${version};
+      done
 
 release_docker_images:
   when: manual

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -48,8 +48,9 @@ for integ_version in $integration_versions; do
   curl -v -f -X POST \
     -F token=$MENDER_QA_TRIGGER_TOKEN \
     -F ref=master \
-    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=true \
-    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=true \
+    -F variables[PUBLISH_DOCKER_CLIENT_IMAGES]=true \
+    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=false \
+    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[TEST_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB_GPT]=false \


### PR DESCRIPTION
The client repo relies on this script to trigger the Pipeline with
specific variables to publish the client related Docker images, which
was broken since we introduced the releases as a manual step.

This commit creates an specific job and Pipeline variable for this, and
adapts the script accordingly.