### PR TITLE
Restore the build/test variables in gitlab_trigger_client_publish

### DIFF
--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -49,8 +49,8 @@ for integ_version in $integration_versions; do
     -F token=$MENDER_QA_TRIGGER_TOKEN \
     -F ref=master \
     -F variables[PUBLISH_DOCKER_CLIENT_IMAGES]=true \
-    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=false \
-    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=false \
+    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=true \
+    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=true \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[TEST_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB_GPT]=false \


### PR DESCRIPTION
Removed during 3cefb4a but turned out to be a bad idea: we require at
least the build.

Decided also to restore test to keep the original thought: prevent
publishing anything that might be broken.