### PR TITLE
Amend publish_docker_client_images: missing dependency build_servers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1044,6 +1044,7 @@ publish_docker_client_images:
     - docker:19.03.5-dind
   dependencies:
     - init_workspace
+    - build_servers
     - build_client
   before_script:
     # Check correct dind setup


### PR DESCRIPTION
Amend publish_docker_client_images: missing dependency build_servers as the mender-client-docker is build there and not in build_client.

Follow up of #379 and #380