### PR TITLE
Fix script for backend-tests suite selection

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -877,6 +877,7 @@ test_backend_integration:
       trap handle_exit EXIT
 
     - INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
+    - echo Running backend-tests suite $INTEGRATION_TEST_SUITE
     - cd integration/backend-tests/
 
     # for pre 2.2.x releases, ignore test suite selection and just run open tests
@@ -988,6 +989,7 @@ test_full_integration:
       trap handle_exit EXIT
 
     - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
+    - echo Running integration tests suite $INTEGRATION_TEST_SUITE
     # only do automatic test suite selection if the user wasn't specific
     # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
     - if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -881,7 +881,7 @@ test_backend_integration:
     - cd integration/backend-tests/
 
     # for pre 2.2.x releases, ignore test suite selection and just run open tests
-    - if ./run --help | grep -q "\-\-suite"; then
+    - if ./run --help | grep -e --suite; then
         ./run --suite $INTEGRATION_TEST_SUITE;
       else
         PYTEST_ARGS="-k 'not Multitenant'" ./run;


### PR DESCRIPTION
It seems like GitLab mangles somehow the previous escape sequences
making the grep to fail and calling always ./run with no --suite
parameter (de facto running only Open Source tests).

Use grep -e to get the following argument as the pattern.

This has probably been broken since the introduction of this feature,
several weeks ago.