### PR TITLE
Saving backend integration tests logs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -896,9 +896,7 @@ test_backend_integration:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-    - if [ -f ${CI_PROJECT_DIR}/../integration/backend-tests/acceptance.* ]; then
-        ls ${CI_PROJECT_DIR}/../integration/backend-tests/acceptance.* | xargs -n 1 -i cp {} .;
-      fi
+    - find ${CI_PROJECT_DIR}/../integration/backend-tests -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec cp "{}" . \;
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
     - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
     - cp /var/log/sysstat/sysstat.log .


### PR DESCRIPTION
Attempt to fix (see [[1](https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/513913768)]):

```bash
/bin/bash: line 225: [: /builds/Northern.tech/Mender/mender-qa/../integration/backend-tests/acceptance.PpOPHk: binary operator expected
```
Links
[1] https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/513913768

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>