### PR TITLE
Disallow integration test failures

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -933,7 +933,6 @@ test_full_integration:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
-  allow_failure: true
   stage: test
   image: docker:18-dind
   tags:


### PR DESCRIPTION
The integration tests suite has been stable for quite some time now.