### PR TITLE
py3-pip

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -100,7 +100,7 @@ init_workspace:
       trap handle_exit EXIT
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk --update --no-cache add git openssh bash python3 curl
+    - apk --update --no-cache add git openssh bash python3 curl py3-pip
     - pip3 install --upgrade pyyaml
 
     # Prepare SSH keys


### PR DESCRIPTION
Fix for `/bin/sh: eval: line 185: pip3: not found` on init_workspace [[1](https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/574911430)]

[1] https://gitlab.com/Northern.tech/Mender/mender-qa/-/jobs/574911430

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>