### PR TITLE
Post Github status for the entire mender-qa pipeline.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,8 +78,6 @@ variables:
 include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
-  - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-github-status-updates.yml'
 
 stages:
   # .pre and .post have no effect and are only for documentation purposes. .pre
@@ -92,18 +90,6 @@ stages:
   - publish
   - release
   - .post
-
-# Skip the GitHub reports for master, as this repo is most of the times in master
-# while running the integration pipeline for other repos' PRs
-github:start:
-  except:
-    - master
-github:success:
-  except:
-    - master
-github:failure:
-  except:
-    - master
 
 mender-qa:start:
   stage: .pre

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -82,11 +82,16 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
 
 stages:
+  # .pre and .post have no effect and are only for documentation purposes. .pre
+  # and .post stages run at the very start and very end of a pipeline,
+  # regardless of where they are defined.
+  - .pre
   - init
   - build
   - test
   - publish
   - release
+  - .post
 
 # Skip the GitHub reports for master, as this repo is most of the times in master
 # while running the integration pipeline for other repos' PRs
@@ -99,6 +104,29 @@ github:success:
 github:failure:
   except:
     - master
+
+mender-qa:start:
+  stage: .pre
+  # Keep overhead low by using a small image with curl preinstalled.
+  image: appropriate/curl
+  script:
+    - $CI_PROJECT_DIR/scripts/github_pull_request_status pending "mender-qa pipeline running" $CI_PIPELINE_URL ci/mender-qa
+
+mender-qa:success:
+  stage: .post
+  when: on_success
+  # Keep overhead low by using a small image with curl preinstalled.
+  image: appropriate/curl
+  script:
+    - $CI_PROJECT_DIR/scripts/github_pull_request_status success "mender-qa pipeline passed" $CI_PIPELINE_URL ci/mender-qa
+
+mender-qa:failure:
+  stage: .post
+  when: on_failure
+  # Keep overhead low by using a small image with curl preinstalled.
+  image: appropriate/curl
+  script:
+    - $CI_PROJECT_DIR/scripts/github_pull_request_status failure "mender-qa pipeline failed" $CI_PIPELINE_URL ci/mender-qa
 
 init_workspace:
   stage: init

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -95,6 +95,8 @@ mender-qa:start:
   stage: .pre
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
+  before_script:
+    - apk --update add jq
   script:
     - $CI_PROJECT_DIR/scripts/github_pull_request_status pending "mender-qa pipeline running" $CI_PIPELINE_URL ci/mender-qa
 
@@ -103,6 +105,8 @@ mender-qa:success:
   when: on_success
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
+  before_script:
+    - apk --update add jq
   script:
     - $CI_PROJECT_DIR/scripts/github_pull_request_status success "mender-qa pipeline passed" $CI_PIPELINE_URL ci/mender-qa
 
@@ -111,6 +115,8 @@ mender-qa:failure:
   when: on_failure
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
+  before_script:
+    - apk --update add jq
   script:
     - $CI_PROJECT_DIR/scripts/github_pull_request_status failure "mender-qa pipeline failed" $CI_PIPELINE_URL ci/mender-qa
 
@@ -130,7 +136,7 @@ init_workspace:
       trap handle_exit EXIT
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk --update add git openssh bash python3 curl py3-pip
+    - apk --update add git openssh bash python3 curl py3-pip jq
     - pip3 install --upgrade pyyaml
 
     # Post job status
@@ -924,7 +930,7 @@ test_backend_integration:
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
     - apk --update add bash git py-pip gcc make python2-dev
-      libc-dev libffi-dev openssl-dev python3 curl
+      libc-dev libffi-dev openssl-dev python3 curl jq
     - pip install docker-compose==1.24.0
     - pip3 install pyyaml
     # Restore workspace from init stage
@@ -1049,13 +1055,14 @@ test_full_integration:
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
+    # Post job status
+    - apk --update add curl jq
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+
     # Get and install the integration test requirements
-    - apk --update add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
+    - apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
     - pip install  -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
     - pip3 install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
-
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images
     - for repo in `integration/extra/release_tool.py -l docker`; do
@@ -1413,6 +1420,9 @@ build_mender-cli:
     # Export GOPATH
     - export GOPATH="$WORKSPACE/go"
 
+    - apt-get update -q
+    - apt-get install -qqy jq
+
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
@@ -1459,7 +1469,7 @@ build_mender-artifact:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk --update add bash curl git make
+    - apk --update add bash curl git make jq
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env /tmp

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,7 +130,7 @@ init_workspace:
       trap handle_exit EXIT
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk --update --no-cache add git openssh bash python3 curl py3-pip
+    - apk --update add git openssh bash python3 curl py3-pip
     - pip3 install --upgrade pyyaml
 
     # Post job status
@@ -923,11 +923,10 @@ test_backend_integration:
     - sleep 10
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
-    - apk --update --no-cache add bash git py-pip gcc make python2-dev
+    - apk --update add bash git py-pip gcc make python2-dev
       libc-dev libffi-dev openssl-dev python3 curl
     - pip install docker-compose==1.24.0
     - pip3 install pyyaml
-    - rm -rf /var/cache/apk/*
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -961,7 +960,7 @@ test_backend_integration:
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually
-    - apk --update --no-cache add sysstat
+    - apk add sysstat
     - ln -s /var/log/sa/ /var/log/sysstat
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
@@ -1041,7 +1040,6 @@ test_full_integration:
     - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
 
-    - rm -rf /var/cache/apk/*
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -1052,7 +1050,7 @@ test_full_integration:
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
     # Get and install the integration test requirements
-    - apk --update --no-cache add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
+    - apk --update add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
     - pip install  -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
     - pip3 install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
@@ -1076,7 +1074,7 @@ test_full_integration:
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually
-    - apk --update --no-cache add sysstat
+    - apk add sysstat
     - ln -s /var/log/sa/ /var/log/sysstat
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
@@ -1147,7 +1145,7 @@ test_full_integration:
   dependencies:
     - init_workspace
   before_script:
-    - apk add --no-cache bash curl findutils git
+    - apk --update add bash curl findutils git
     - tar xf ${CI_PROJECT_DIR}/workspace.tar.gz ./go/src/github.com/mendersoftware/mender
     - mv go/src/github.com/mendersoftware/mender ${CI_PROJECT_DIR}/mender
   script:
@@ -1280,7 +1278,7 @@ publish_docker_client_images:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk add git python3 py3-pip
+    - apk --update add git python3 py3-pip
     - pip3 install --upgrade pyyaml
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -1320,7 +1318,7 @@ release_docker_images:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk add git python3 py3-pip
+    - apk --update add git python3 py3-pip
     - pip3 install --upgrade pyyaml
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -1461,7 +1459,7 @@ build_mender-artifact:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk add --no-cache bash curl git make
+    - apk --update add bash curl git make
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env /tmp

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,6 +119,9 @@ init_workspace:
     - apk --update --no-cache add git openssh bash python3 curl py3-pip
     - pip3 install --upgrade pyyaml
 
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+
     # Prepare SSH keys
     - eval $(ssh-agent -s)
     - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
@@ -145,16 +148,12 @@ init_workspace:
       fi
     - (cd mender-qa && echo -e "# $(git log -n1 --oneline)\nexport MENDER_QA_REV=$MENDER_QA_REV\nexport MENDER_QA_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
 
-    # Add integration first, as github_pull_request_status depends on release_tool.
     - git clone https://github.com/mendersoftware/integration
     - (cd integration &&
       git fetch -u -f origin ${INTEGRATION_REV}:pr &&
       git checkout pr ||
       git checkout -f -b pr ${INTEGRATION_REV})
     - (cd integration && echo -e "# $(git log -n1 --oneline)\nexport INTEGRATION_REV=$INTEGRATION_REV\nexport INTEGRATION_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Add other repositories.
     - git clone https://github.com/mendersoftware/meta-mender

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -39,35 +39,18 @@ for key in $(env | sed -e 's/=.*//'); do
         # GitLab script defines env variables with _GIT_SHA suffix for the PR commit under test
         git_commit="$(eval echo \$${key}_GIT_SHA)"
     else
-        # Fallback to classic method of relying on locally cloned repos
-        case "$key" in
-            MENDER_QA_REV)
-                location=$WORKSPACE/mender-qa
-                ;;
-            META_MENDER_REV)
-                location=$WORKSPACE/meta-mender
-                ;;
-            *_REV)
-                if ! $WORKSPACE/integration/extra/release_tool.py --version-of $repo; then
-                    # If the release tool doesn't recognize the repository, don't use it.
-                    continue
-                fi
-                location=
-                if [ -d "$WORKSPACE/$repo" ]; then
-                    location="$WORKSPACE/$repo"
-                elif [ -d "$WORKSPACE/go/src/github.com/mendersoftware/$repo" ]; then
-                    location="$WORKSPACE/go/src/github.com/mendersoftware/$repo"
-                else
-                    echo "github_pull_request_status: Unable to find repository location: $repo"
-                    return 1
-                fi
-                ;;
-            *)
-                # Not a revision, go to next entry.
-                continue
-                ;;
-        esac
-        git_commit=$(cd "$location" && git rev-parse HEAD)
+        # Use Github API to fetch commit SHAs
+        eval sha_endpoint=https://api.github.com/repos/mendersoftware/$repo/git/ref/\$${key}
+        response="$(curl -fH "Authorization: bearer $GITHUB_BOT_TOKEN" $sha_endpoint)"
+        if [ $? -ne 0 ]; then
+            continue
+        fi
+        # Ideally we should use jq here, but this is run in so many different
+        # jobs, that we will use the fully portable sed instead.
+        git_commit="$(echo "$response" | sed -ne '/^ *"sha":/{s/^ *"sha": *"\([^"]*\)".*$/\1/; p}')"
+        if [ $? -ne 0 ]; then
+            continue
+        fi
     fi
     pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
 

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 request_body=$(cat <<EOF
 {
@@ -24,7 +24,7 @@ fi
 # Split on newlines
 IFS='
 '
-for key in $(compgen -A export); do
+for key in $(env | sed -e 's/=.*//'); do
     if ! eval echo \$$key | egrep -q "^pull/[0-9]+/head$"; then
         # Not a pull request, skip.
         continue
@@ -34,7 +34,7 @@ for key in $(compgen -A export); do
         continue
     fi
 
-    repo=$(tr '[A-Z_]' '[a-z-]' <<<${key%_REV})
+    repo=$(echo ${key%_REV} | tr '[A-Z_]' '[a-z-]')
     if [ -n "$(eval echo \$${key}_GIT_SHA)" ]; then
         # GitLab script defines env variables with _GIT_SHA suffix for the PR commit under test
         git_commit="$(eval echo \$${key}_GIT_SHA)"

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -45,9 +45,7 @@ for key in $(env | sed -e 's/=.*//'); do
         if [ $? -ne 0 ]; then
             continue
         fi
-        # Ideally we should use jq here, but this is run in so many different
-        # jobs, that we will use the fully portable sed instead.
-        git_commit="$(echo "$response" | sed -ne '/^ *"sha":/{s/^ *"sha": *"\([^"]*\)".*$/\1/; p}')"
+        git_commit="$(echo "$response" | jq -r '.object.sha')"
         if [ $? -ne 0 ]; then
             continue
         fi

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -71,7 +71,7 @@ for key in $(compgen -A export); do
     fi
     pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
 
-    curl -iv -H "Authorization: bearer $GITHUB_BOT_TOKEN" \
+    curl -H "Authorization: bearer $GITHUB_BOT_TOKEN" \
          -d "$request_body" \
          "$pr_status_endpoint"
 done


### PR DESCRIPTION
This has several advantages compared to the existing method which
posts the status from within each job:

* If we add a new stage or job, there is no risk of forgetting to add
  a status update there.

* The status stays yellow until the whole pipeline is finished,
  instead of flipping between green and yellow as it does
  currently. This helps prevent mismerging because the pipeline looks
  green when it's actually unfinished.

* Potentially we could remove the much more complicated per-job status
  updates, and save some code, but they are still useful, and we
  already have them, so I'm not touching that now.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>