### PR TITLE
[github_pull_request_status] Print variables before curl call

### DIFF
--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -25,12 +25,16 @@ fi
 IFS='
 '
 for key in $(env | sed -e 's/=.*//'); do
-    if ! eval echo \$$key | egrep -q "^pull/[0-9]+/head$"; then
-        # Not a pull request, skip.
+    if ! echo $key | egrep -q "_REV"; then
+        # Not a Mender repo variable
         continue
     fi
     if echo $key | egrep -q "^DOCKER_ENV_"; then
         # Skip GitLab/Docker duplicated environment vars, i.e. MENDER_REV has a DOCKER_ENV_MENDER_REV
+        continue
+    fi
+    if ! eval echo \$$key | egrep -q "^pull/[0-9]+/head$"; then
+        # Not a pull request, skip.
         continue
     fi
 

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -52,8 +52,20 @@ for key in $(env | sed -e 's/=.*//'); do
     fi
     pr_status_endpoint=https://api.github.com/repos/mendersoftware/$repo/statuses/$git_commit
 
+    # Print the variables
+    echo "Reporting GitHub status for:"
+    echo "    key=$key"
+    echo "    repo=$repo"
+    echo "    sha_endpoint=$sha_endpoint"
+    echo "    git_commit=$git_commit"
+    echo "    pr_status_endpoint=$pr_status_endpoint"
+    echo "    request_body:"
+    echo "$request_body"
+    echo
+
     curl -H "Authorization: bearer $GITHUB_BOT_TOKEN" \
          -d "$request_body" \
          "$pr_status_endpoint"
 done
 
+IFS=' '

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -3,7 +3,7 @@
 set -e -x -E
 
 
-echo $WORKSPACE
+echo "WORKSPACE=$WORKSPACE"
 
 declare -a CONFIG_MACHINE_NAMES
 declare -a CONFIG_BOARD_NAMES
@@ -11,16 +11,6 @@ declare -a CONFIG_IMAGE_NAMES
 declare -a CONFIG_DEVICE_TYPES
 
 export PATH=$PATH:$WORKSPACE/go/bin
-
-declare -A TEST_TRACKER
-
-is_poky_branch() {
-    if egrep -q "^ *DISTRO_CODENAME *= *\"$1\" *\$" $WORKSPACE/meta-poky/conf/distro/poky.conf; then
-        return 0
-    else
-        return 1
-    fi
-}
 
 is_building_dockerized_board() {
     local ret=0
@@ -543,6 +533,7 @@ build_and_test_client() {
         # run tests on qemu
         if is_testing_board $board_name; then
             export QEMU_SYSTEM_ARM="/usr/bin/qemu-system-arm"
+            # TODO: clean-up python2 support after warrior goes unsupported
             local python3_supported=false
             local pip_cmd=pip2
             if [ -f $WORKSPACE/meta-mender/tests/acceptance/requirements_py3.txt ]; then


### PR DESCRIPTION
* [jenkins-yoctobuild-build.sh] Minor cleanups

* [github_pull_request_status] Print variables before curl call
It seems like the script does not work (some times?) for some enterprise
repos. These prints will help debugging the issue.

* [github_pull_request_status] Avoid processing other env variables
Early filter for env variables like *_REV, to avoid calling eval on
arbitrary strings from multi-line env variables.
