### PR TITLE
Fix private repositories not reporting build status in many cases.

### DIFF
--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -44,13 +44,13 @@ for key in $(env | sed -e 's/=.*//'); do
         git_commit="$(eval echo \$${key}_GIT_SHA)"
     else
         # Use Github API to fetch commit SHAs
-        eval sha_endpoint=https://api.github.com/repos/mendersoftware/$repo/git/ref/\$${key}
+        eval sha_endpoint=https://api.github.com/repos/mendersoftware/$repo/status/\$${key}
         echo "Querying API: $sha_endpoint"
         response="$(curl -fH "Authorization: bearer $GITHUB_BOT_TOKEN" $sha_endpoint)"
         if [ $? -ne 0 ]; then
             continue
         fi
-        git_commit="$(echo "$response" | jq -r '.object.sha')"
+        git_commit="$(echo "$response" | jq -r '.sha')"
         if [ $? -ne 0 ]; then
             continue
         fi


### PR DESCRIPTION
The problem is that repo:status permission on Github does not grant
access to the general git API, so we cannot query the commit SHA.
However, we have access to the "status" API. The interesting thing is
that I completely stumbled upon this API, and I cannot find that it's
documented on the the Github API pages. It is not the same as the
"statuses" API, which is documented (and which we use a few lines
later). So it's possible that this will break some day, but until
then...

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>