### PR TITLE
Remove mender-image-tests handling, use submodule's hash

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ variables:
   MENDER_STRESS_TEST_CLIENT_REV: "master"
   META_OPENEMBEDDED_REV: "dunfell"
   META_RASPBERRYPI_REV: "dunfell"
-  MENDER_IMAGE_TESTS_REV: "master"
   AUDITLOGS_REV: "master"
   MTLS_AMBASSADOR_REV: "master"
 
@@ -325,13 +324,6 @@ init_workspace:
       git checkout pr ||
       git checkout -f -b pr ${MENDER_CLI_REV})
     - (cd go/src/github.com/mendersoftware/mender-cli && echo -e "# $(git log -n1 --oneline)\nexport MENDER_CLI_REV=$MENDER_CLI_REV\nexport MENDER_CLI_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
-
-    - git clone https://github.com/mendersoftware/mender-image-tests
-    - (cd mender-image-tests &&
-      git fetch -u -f origin ${MENDER_IMAGE_TESTS_REV}:pr &&
-      git checkout pr ||
-      git checkout -f -b pr ${MENDER_IMAGE_TESTS_REV})
-    - (cd mender-image-tests && echo -e "# $(git log -n1 --oneline)\nexport MENDER_IMAGE_TESTS_REV=$MENDER_IMAGE_TESTS_REV\nexport MENDER_IMAGE_TESTS_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env)
 
     - git clone git@github.com:mendersoftware/auditlogs go/src/github.com/mendersoftware/auditlogs
     - (cd go/src/github.com/mendersoftware/auditlogs &&

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -242,22 +242,9 @@ docker ps -q -a | xargs -r docker rm -f || true
 docker system prune -f -a
 sudo killall -s9 mender-stress-test-client || true
 
-# ---------------------------------------------------
-# Generic setup.
-# ---------------------------------------------------
-
-# Handle sub modules. This is a noop for branches that don't have them. It only
-# looks complicated because in Jenkins we want to build the repository it
-# cloned, not the upstream repository.
+# Handle meta-mender sub modules.
 cd $WORKSPACE/meta-mender
-git submodule deinit -f . || true
-rm -rf .git/modules
-git submodule init
-git config submodule.tests/acceptance/image-tests.url $WORKSPACE/mender-image-tests
-# This may fail if a branch is missing from Jenkins' clone. Doesn't matter, we
-# will checkout HEAD instead.
-git submodule update || git submodule foreach git reset --hard
-git submodule foreach "git fetch origin HEAD && git checkout FETCH_HEAD"
+git submodule update --init --recursive
 cd $WORKSPACE
 
 # ---------------------------------------------------
@@ -575,8 +562,6 @@ build_and_test_client() {
             fi
 
             local pytest_args=
-            # Assuming thud or newer
-            pytest_args="--no-pull"
             # Assuming rocko or newer
             pytest_args="$pytest_args --commercial-tests"
 

--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -539,10 +539,10 @@ build_and_test_client() {
                 sudo patch -p1 /usr/local/lib/python2.7/dist-packages/fabric/network.py b60247d78e9a7b541b3ed5de290fdeef2039c6df.patch || true
             fi
 
-	    # Zeus and older do not have this.
-	    if grep -q mender-testing-enabled $WORKSPACE/meta-mender/meta-mender-core/classes/mender-maybe-setup.bbclass; then
-		echo 'MENDER_FEATURES_ENABLE_append = " mender-testing-enabled"' >> $BUILDDIR/conf/local.conf
-	    fi
+            # Zeus and older do not have this.
+            if grep -q mender-testing-enabled $WORKSPACE/meta-mender/meta-mender-core/classes/mender-maybe-setup.bbclass; then
+            echo 'MENDER_FEATURES_ENABLE_append = " mender-testing-enabled"' >> $BUILDDIR/conf/local.conf
+            fi
 
             bitbake $image_name
 


### PR DESCRIPTION
The previous behavior was counter-intuitive and it is making it
difficult to introduce changes in mender-image-tests while keeping
backwards compatibility with Python 2 (used in warrior).

Remove the special logic and instead rely solely on the Git submodules
hashes. We also have now the aid of dependabot to keep these up to date.

Remove also `--no-pull` flag for acceptance tests, as it will now be
unsupported by the test framework.