### PR TITLE
Skip Docker build for vexpress-qemu

### DIFF
--- a/scripts/jenkins-yoctobuild-build.sh
+++ b/scripts/jenkins-yoctobuild-build.sh
@@ -14,8 +14,7 @@ export PATH=$PATH:$WORKSPACE/go/bin
 
 is_building_dockerized_board() {
     local ret=0
-    is_building_board vexpress-qemu \
-        || is_building_board qemux86-64-uefi-grub \
+    is_building_board qemux86-64-uefi-grub \
         || ret=$?
     return $ret
 }


### PR DESCRIPTION
This image is not used anymore for integration tests and the wrapper has
been removed from meta-mender/master.

See https://github.com/mendersoftware/meta-mender/pull/1135