### PR TITLE
Switch from "dependencies" to "needs" to enable more parallelism.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -369,6 +369,8 @@ init_workspace:
 
 .template_build_test_acc: &build_and_test_acceptance
   image: teracy/ubuntu:18.04-dind-18.09.9
+  needs:
+    - init_workspace
   services:
   - docker:18-dind
   tags:
@@ -495,8 +497,6 @@ build_client:
       - $BUILD_CLIENT == "true"
       - $RUN_INTEGRATION_TESTS == "true"
   stage: build
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
@@ -527,8 +527,6 @@ build_servers:
     variables:
       - $BUILD_SERVERS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_servers
@@ -565,8 +563,6 @@ test_accep_qemux86_64_uefi_grub:
       - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
       - $TEST_QEMUX86_64_UEFI_GRUB == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
@@ -605,8 +601,6 @@ test_accep_vexpress_qemu:
       - $BUILD_VEXPRESS_QEMU == "true"
       - $TEST_VEXPRESS_QEMU == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu
@@ -645,8 +639,6 @@ test_accep_qemux86_64_bios_grub:
       - $BUILD_QEMUX86_64_BIOS_GRUB == "true"
       - $TEST_QEMUX86_64_BIOS_GRUB == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
@@ -685,8 +677,6 @@ test_accep_qemux86_64_bios_grub_gpt:
       - $BUILD_QEMUX86_64_BIOS_GRUB_GPT == "true"
       - $TEST_QEMUX86_64_BIOS_GRUB_GPT == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
@@ -725,8 +715,6 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
       - $BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
       - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
@@ -768,8 +756,6 @@ test_accep_vexpress_qemu_flash:
       - $BUILD_VEXPRESS_QEMU_FLASH == "true"
       - $TEST_VEXPRESS_QEMU_FLASH == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_flash
@@ -808,8 +794,6 @@ test_accep_beagleboneblack:
       - $BUILD_BEAGLEBONEBLACK == "true"
       - $TEST_BEAGLEBONEBLACK == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_beagleboneblack
@@ -849,8 +833,6 @@ test_accep_raspberrypi3:
       - $BUILD_RASPBERRYPI3 == "true"
       - $TEST_RASPBERRYPI3 == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_raspberrypi3
@@ -890,8 +872,6 @@ test_accep_raspberrypi4:
       - $BUILD_RASPBERRYPI4 == "true"
       - $TEST_RASPBERRYPI4 == "true"
   stage: test
-  needs:
-    - init_workspace
   <<: *build_and_test_acceptance
   variables:
     JOB_BASE_NAME: mender_raspberrypi4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -495,7 +495,7 @@ build_client:
       - $BUILD_CLIENT == "true"
       - $RUN_INTEGRATION_TESTS == "true"
   stage: build
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -527,7 +527,7 @@ build_servers:
     variables:
       - $BUILD_SERVERS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -565,7 +565,7 @@ test_accep_qemux86_64_uefi_grub:
       - $BUILD_QEMUX86_64_UEFI_GRUB == "true"
       - $TEST_QEMUX86_64_UEFI_GRUB == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -605,7 +605,7 @@ test_accep_vexpress_qemu:
       - $BUILD_VEXPRESS_QEMU == "true"
       - $TEST_VEXPRESS_QEMU == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -645,7 +645,7 @@ test_accep_qemux86_64_bios_grub:
       - $BUILD_QEMUX86_64_BIOS_GRUB == "true"
       - $TEST_QEMUX86_64_BIOS_GRUB == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -685,7 +685,7 @@ test_accep_qemux86_64_bios_grub_gpt:
       - $BUILD_QEMUX86_64_BIOS_GRUB_GPT == "true"
       - $TEST_QEMUX86_64_BIOS_GRUB_GPT == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -725,7 +725,7 @@ test_accep_vexpress_qemu_uboot_uefi_grub:
       - $BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
       - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -768,7 +768,7 @@ test_accep_vexpress_qemu_flash:
       - $BUILD_VEXPRESS_QEMU_FLASH == "true"
       - $TEST_VEXPRESS_QEMU_FLASH == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -808,7 +808,7 @@ test_accep_beagleboneblack:
       - $BUILD_BEAGLEBONEBLACK == "true"
       - $TEST_BEAGLEBONEBLACK == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -849,7 +849,7 @@ test_accep_raspberrypi3:
       - $BUILD_RASPBERRYPI3 == "true"
       - $TEST_RASPBERRYPI3 == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -890,7 +890,7 @@ test_accep_raspberrypi4:
       - $BUILD_RASPBERRYPI4 == "true"
       - $TEST_RASPBERRYPI4 == "true"
   stage: test
-  dependencies:
+  needs:
     - init_workspace
   <<: *build_and_test_acceptance
   variables:
@@ -933,7 +933,7 @@ test_backend_integration:
   image: docker:18-dind
   tags:
     - mender-qa-slave-highcpu
-  dependencies:
+  needs:
     - init_workspace
     - build_servers
     - build_mender-artifact
@@ -1048,7 +1048,7 @@ test_full_integration:
   image: docker:18-dind
   tags:
     - mender-qa-slave-highmem
-  dependencies:
+  needs:
     - init_workspace
     - build_servers
     - build_client
@@ -1170,8 +1170,6 @@ test_full_integration:
       - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"
       - $MENDER_REV =~ /pull\/.*\/head/
   stage: publish
-  dependencies:
-    - init_workspace
   image: golang:1.14-alpine3.11
   before_script:
     - apk add --no-cache git
@@ -1222,7 +1220,7 @@ publish_accep_qemux86_64_uefi_grub:
   except:
     variables:
       - $TEST_QEMUX86_64_UEFI_GRUB != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_qemux86_64_uefi_grub
   variables:
@@ -1233,7 +1231,7 @@ publish_accep_vexpress_qemu:
   except:
     variables:
       - $TEST_VEXPRESS_QEMU != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_vexpress_qemu
   variables:
@@ -1244,7 +1242,7 @@ publish_accep_qemux86_64_bios_grub:
   except:
     variables:
       - $TEST_QEMUX86_64_BIOS_GRUB != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_qemux86_64_bios_grub
   variables:
@@ -1255,7 +1253,7 @@ publish_accep_qemux86_64_bios_grub_gpt:
   except:
     variables:
       - $TEST_QEMUX86_64_BIOS_GRUB_GPT != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_qemux86_64_bios_grub_gpt
   variables:
@@ -1266,7 +1264,7 @@ publish_accep_vexpress_qemu_uboot_uefi_grub:
   except:
     variables:
       - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_vexpress_qemu_uboot_uefi_grub
   variables:
@@ -1277,7 +1275,7 @@ publish_accep_vexpress_qemu_flash:
   except:
     variables:
       - $TEST_VEXPRESS_QEMU_FLASH != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_vexpress_qemu_flash
   variables:
@@ -1288,7 +1286,7 @@ publish_accep_beagleboneblack:
   except:
     variables:
       - $TEST_BEAGLEBONEBLACK != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_beagleboneblack
   variables:
@@ -1299,7 +1297,7 @@ publish_accep_raspberrypi3:
   except:
     variables:
       - $TEST_RASPBERRYPI3 != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_raspberrypi3
   variables:
@@ -1310,7 +1308,7 @@ publish_accep_raspberrypi4:
   except:
     variables:
       - $TEST_RASPBERRYPI4 != "true"
-  dependencies:
+  needs:
     - init_workspace
     - test_accep_raspberrypi4
   variables:
@@ -1328,7 +1326,7 @@ publish_docker_client_images:
   image: docker
   services:
     - docker:19.03.5-dind
-  dependencies:
+  needs:
     - init_workspace
     - build_servers
     - build_client
@@ -1364,11 +1362,14 @@ publish_docker_client_images:
 
 
 .template_release_docker_images:
+  only:
+    variables:
+      - ($BUILD_SERVERS == "true" && $BUILD_CLIENT == "true") || $RUN_INTEGRATION_TESTS == "true"
   stage: release
   image: docker
   services:
     - docker:19.03.5-dind
-  dependencies:
+  needs:
     - init_workspace
     - build_servers
     - build_client
@@ -1475,7 +1476,7 @@ build_mender-cli:
       - $BUILD_SERVERS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
   image: golang:1.11.4
-  dependencies:
+  needs:
     - init_workspace
   before_script:
     # Default value, will later be overwritten if successful
@@ -1532,7 +1533,7 @@ build_mender-artifact:
     - docker:dind
   tags:
     - docker
-  dependencies:
+  needs:
     - init_workspace
   before_script:
     # Default value, will later be overwritten if successful
@@ -1575,9 +1576,12 @@ build_mender-artifact:
       - stage-artifacts/
 
 .template_release_binary_tools:
+  only:
+    variables:
+      - ($BUILD_SERVERS == "true" && $BUILD_CLIENT == "true") || $RUN_INTEGRATION_TESTS == "true"
   stage: release
   image: debian:buster
-  dependencies:
+  needs:
     - init_workspace
     - build_mender-cli
     - build_mender-artifact


### PR DESCRIPTION
Not all "dependencies" keys are changed to "needs". Jobs that execute
strictly last are not changed to avoid having an excessive list of
"needs" entries.

One "dependencies" key was removed because it is in a template, and
the default doesn't make sense on its own.

And finally, since we now "need" jobs that are conditional, we have to
re-specify all the conditions for the jobs that are depended upon.

release_board_artifacts would have a huge list if done this way, so
decided to not use "needs" for this job, since its dependencies
usually finish last anyway.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>