### PR TITLE
dind: Update dind images and setup default environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,6 +77,15 @@ variables:
   # Global environment variables (not meant to be changed)
   DEBIAN_FRONTEND: noninteractive
 
+  # Docker dind configuration.
+  # To use dind, make sure gitlab-runner's configuration
+  # has a common mount for /certs (i.e. runners.docker.volumes) directory
+  # and that the dind service name is always docker (default hostname).
+  DOCKER_HOST: "tcp://docker:2376"
+  DOCKER_CERT_PATH: "/certs/client"
+  DOCKER_TLS_VERIFY: 1
+  DOCKER_TLS_CERTDIR: "/certs"
+
 include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
@@ -124,7 +133,7 @@ mender-qa:failure:
 
 init_workspace:
   stage: init
-  image: alpine:latest
+  image: alpine:3.12
   script:
     # Traps only work if executed in a sub shell.
     - "("
@@ -368,18 +377,16 @@ init_workspace:
       - build_revisions.env
 
 .template_build_test_acc: &build_and_test_acceptance
-  image: teracy/ubuntu:18.04-dind-18.09.9
+  image: ubuntu:18.04
   needs:
     - init_workspace
   services:
-  - docker:18-dind
+  - docker:19.03-dind
   tags:
     - mender-qa-slave-highcpu
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
-    # Check correct dind setup
-    - docker version
     # Export required yoctobuild script variables
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - export GOPATH="$WORKSPACE/go"
@@ -391,12 +398,14 @@ init_workspace:
     # basic tools
     - apt-get update -q
     - apt-get install -qqy
-      git wget gnupg2 pass autoconf automake build-essential diffstat gawk chrpath
-      libsdl1.2-dev e2tools nfs-client s3cmd psmisc screen libssl-dev python-dev bash
+      git docker.io wget gnupg2 pass autoconf automake build-essential diffstat gawk chrpath
+      libsdl1.2-dev e2tools nfs-client s3cmd psmisc screen libssl-dev python-dev bash curl
       libxml2-dev libxslt-dev libffi-dev nodejs libyaml-dev sysbench texinfo pkg-config
       zlib1g-dev libaio-dev libbluetooth-dev libbrlapi-dev libbz2-dev libglib2.0-dev
       libfdt-dev libpixman-1-dev zlib1g-dev jq liblzo2-dev device-tree-compiler
       qemu-system-x86 qemu-system-arm bc kpartx liblzma-dev cpio sudo awscli gdisk
+    # Verify correct dind setup
+    - docker version
     # Prepare mender user
     - useradd -m -u 1010 mender || true
     - mkdir -p /home/mender/.ssh
@@ -449,8 +458,7 @@ init_workspace:
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
     # Setup KVM
     - usermod -a -G kvm mender
-    - apt-get install -qqy kmod libvirt-bin qemu-utils qemu-kvm
-    - apt-get install -qqy linux-modules-`uname -r`
+    - apt-get install -qqy kmod libvirt-bin qemu-utils qemu-kvm linux-modules-`uname -r`
     # Enable nesting VMs
     - modprobe -r kvm_intel
     - modprobe kvm_intel nested=Y
@@ -940,7 +948,9 @@ test_backend_integration:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
   stage: test
-  image: docker:18-dind
+  image: docker/compose:alpine-1.27.4
+  services:
+    - docker:19.03-dind
   tags:
     - mender-qa-slave-highcpu
   needs:
@@ -951,13 +961,9 @@ test_backend_integration:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
 
-    - /usr/local/bin/dockerd-entrypoint.sh &
-    - sleep 10
-    - export DOCKER_HOST="unix:///var/run/docker.sock"
     - docker version
     - apk --update add bash git py-pip gcc make python2-dev
-      libc-dev libffi-dev openssl-dev python3 curl jq
-    - pip install docker-compose==1.24.0
+      libc-dev libffi-dev openssl-dev python3 curl jq sysstat
     - pip3 install pyyaml
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -992,7 +998,6 @@ test_backend_integration:
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually
-    - apk add sysstat
     - ln -s /var/log/sa/ /var/log/sysstat
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
@@ -1061,7 +1066,17 @@ test_full_integration:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
   stage: test
-  image: docker:18-dind
+  # Integration tests depends on running ssh to containers, we're forced to
+  # run dockerd on the same host.
+  image: docker:19.03-dind
+  variables:
+    # Clear DOCKER_ variables
+    DOCKER_HOST: {}
+    DOCKER_CERT_PATH: {}
+    DOCKER_TLS_VERIFY: {}
+    DOCKER_TLS_CERTDIR: {}
+    DOCKER_CLIENT_TIMEOUT: 300
+    COMPOSE_HTTP_TIMEOUT: 300
   tags:
     - mender-qa-slave-highmem
   needs:
@@ -1069,17 +1084,9 @@ test_full_integration:
     - build_servers
     - build_client
     - build_mender-artifact
-  variables:
-    DOCKER_CLIENT_TIMEOUT: 300
-    COMPOSE_HTTP_TIMEOUT: 300
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
-
-    - /usr/local/bin/dockerd-entrypoint.sh &
-    - sleep 10
-    - export DOCKER_HOST="unix:///var/run/docker.sock"
-    - docker version
 
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -1091,11 +1098,21 @@ test_full_integration:
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
     # Post job status
-    - apk --update add curl jq
+    - apk --update add curl jq sysstat docker-compose hdparm
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
+    # Start dockerd in the background
+    - dockerd &
+    # Wait for dockerd to start
+    - |-
+      MAX_WAIT=10
+      while [ ! -e "/var/run/docker.sock" ] && [ $MAX_WAIT -ge 0 ]; do
+        MAX_WAIT=$(($MAX_WAIT - 1))
+        sleep 1
+      done
+    - docker version # Verify that docker is up and running
+
     # Output storage io stats
-    - apk add hdparm
     - df -h . | tail -1 | awk '{system("hdparm -tT "$1);}'
     # Get and install the integration test requirements
     - apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
@@ -1119,7 +1136,6 @@ test_full_integration:
     # sysstat monitoring suite for Alpine Linux
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually
-    - apk add sysstat
     - ln -s /var/log/sa/ /var/log/sysstat
     - sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
   script:
@@ -1191,9 +1207,11 @@ test_full_integration:
       - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"
       - $MENDER_REV =~ /pull\/.*\/head/
   stage: publish
-  image: golang:1.14-alpine3.11
+  needs:
+    - init_workspace
+  image: golang:1.15-alpine3.12
   before_script:
-    - apk add --no-cache git
+    - apk add git
     # Run go get out of the repo to not modify go.mod
     - cd / && go get github.com/mattn/goveralls && cd -
     # Coveralls env variables:
@@ -1228,7 +1246,7 @@ coveralls:finish-build:
   dependencies:
     - init_workspace
   before_script:
-    - apk add --no-cache git
+    - apk add git
     # Get mender source
     - tar xf ${CI_PROJECT_DIR}/workspace.tar.gz ./go/src/github.com/mendersoftware/mender
     - mv go/src/github.com/mendersoftware/mender ${CI_PROJECT_DIR}/mender
@@ -1346,7 +1364,7 @@ publish_docker_client_images:
   stage: release
   image: docker
   services:
-    - docker:19.03.5-dind
+    - docker:19.03-dind
   needs:
     - init_workspace
     - build_servers
@@ -1387,9 +1405,9 @@ publish_docker_client_images:
     variables:
       - ($BUILD_SERVERS == "true" && $BUILD_CLIENT == "true") || $RUN_INTEGRATION_TESTS == "true"
   stage: release
-  image: docker
+  image: docker:19.03
   services:
-    - docker:19.03.5-dind
+    - docker:19.03-dind
   needs:
     - init_workspace
     - build_servers
@@ -1496,7 +1514,7 @@ build_mender-cli:
     variables:
       - $BUILD_SERVERS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
-  image: golang:1.11.4
+  image: golang:1.15-alpine3.12
   needs:
     - init_workspace
   before_script:
@@ -1514,8 +1532,7 @@ build_mender-cli:
     # Export GOPATH
     - export GOPATH="$WORKSPACE/go"
 
-    - apt-get update -q
-    - apt-get install -qqy jq
+    - apk add jq make curl git
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
@@ -1549,7 +1566,7 @@ build_mender-artifact:
     variables:
       - $BUILD_CLIENT == "true"
       - $RUN_INTEGRATION_TESTS == "true"
-  image: docker
+  image: docker:19.03
   services:
     - docker:dind
   tags:


### PR DESCRIPTION
The new docker environment variable assumes there is a docker:dind
container running in a parallel service with hostname "docker" and
shares the tls certificates bind-mounted to "/certs/client".