### PR TITLE
Stringlify DOCKER_TLS_VERIFY to parse it correctly as json

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,7 +72,7 @@ variables:
   CLEAN_BUILD_CACHE: ""
 
   # Internal address for nfs sstate cache server (northamerica-northeast1-b)
-  SSTATE_CACHE_INTRNL_ADDR: 10.162.0.2
+  SSTATE_CACHE_INTRNL_ADDR: "10.162.0.2"
 
   # Global environment variables (not meant to be changed)
   DEBIAN_FRONTEND: noninteractive
@@ -83,7 +83,7 @@ variables:
   # and that the dind service name is always docker (default hostname).
   DOCKER_HOST: "tcp://docker:2376"
   DOCKER_CERT_PATH: "/certs/client"
-  DOCKER_TLS_VERIFY: 1
+  DOCKER_TLS_VERIFY: "1"
   DOCKER_TLS_CERTDIR: "/certs"
 
 include:


### PR DESCRIPTION
Otherwise the GitLab API returns 500 on our POST to create builds.