### PR TITLE
Restore --update flag for apk in some jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1211,7 +1211,7 @@ test_full_integration:
     - init_workspace
   image: golang:1.15-alpine3.12
   before_script:
-    - apk add git
+    - apk --update add git
     # Run go get out of the repo to not modify go.mod
     - cd / && go get github.com/mattn/goveralls && cd -
     # Coveralls env variables:
@@ -1246,7 +1246,7 @@ coveralls:finish-build:
   dependencies:
     - init_workspace
   before_script:
-    - apk add git
+    - apk --update add git
     # Get mender source
     - tar xf ${CI_PROJECT_DIR}/workspace.tar.gz ./go/src/github.com/mendersoftware/mender
     - mv go/src/github.com/mendersoftware/mender ${CI_PROJECT_DIR}/mender
@@ -1532,7 +1532,7 @@ build_mender-cli:
     # Export GOPATH
     - export GOPATH="$WORKSPACE/go"
 
-    - apk add jq make curl git
+    - apk --update add jq make curl git
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"


### PR DESCRIPTION
They were removed by mistake. The first apk call on each job shall use
update the references before installing anything.