### PR TITLE
Integration tests separation on different jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -801,12 +801,14 @@ test_accep_raspberrypi4:
     reports:
       junit: results_accep_raspberrypi4.xml
 
-test_backend_integration:
+test_backend_integration_enterprise:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
   stage: test
   image: docker/compose:alpine-1.27.4
+  variables:
+    TEST_SUITE: "enterprise"
   services:
     - docker:19.03-dind
   tags:
@@ -831,9 +833,6 @@ test_backend_integration:
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
-
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Load all docker images except client
     - for repo in `integration/extra/release_tool.py -l docker`; do
@@ -868,44 +867,56 @@ test_backend_integration:
       trap handle_exit EXIT
 
     - INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
-    - echo Running backend-tests suite $INTEGRATION_TEST_SUITE
-    - cd integration/backend-tests/
 
-    # From 2.4.x on, the script would download the requirements by default
-    - if ./run --help | grep -e --no-download; then
-        RUN_ARGS="--no-download";
-      fi
+    - >
+      if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
+        # Post job status
+        ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
-    # for pre 2.2.x releases, ignore test suite selection and just run open tests
-    - if ./run --help | grep -e --suite; then
-        ./run --suite $INTEGRATION_TEST_SUITE $RUN_ARGS;
+        echo Running backend-tests suite $INTEGRATION_TEST_SUITE
+        cd integration/backend-tests/
+
+        # From 2.4.x on, the script would download the requirements by default
+        if ./run --help | grep -e --no-download; then
+          RUN_ARGS="--no-download";
+        fi
+
+        # for pre 2.2.x releases, ignore test suite selection and just run open tests
+        if ./run --help | grep -e --suite; then
+          ./run --suite $INTEGRATION_TEST_SUITE $RUN_ARGS;
+        else
+          PYTEST_ARGS="-k 'not Multitenant'" ./run;
+        fi
+
+        # Always keep this at the end of the script stage
+        echo "success" > /JOB_RESULT.txt
       else
-        PYTEST_ARGS="-k 'not Multitenant'" ./run;
+        echo "skipped" > /JOB_RESULT.txt
       fi
-
-    # Always keep this at the end of the script stage
-    - echo "success" > /JOB_RESULT.txt
 
     - ")"
 
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - >
+      if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
+        if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-    - find ${CI_PROJECT_DIR}/../integration/backend-tests -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec cp "{}" . \;
-    - ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
-    - ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
+        find ${CI_PROJECT_DIR}/../integration/backend-tests -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec cp "{}" . \;
+        ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
+        ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
 
-    - if [ "$NIGHTLY_BUILD" = "true" ]; then
-    -   ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 7 nightly-$(date +%Y-%m-%d) results_backend_integration_open.xml
-    -   ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 8 nightly-$(date +%Y-%m-%d) results_backend_integration_enterprise.xml
-    - fi
+        if [ "$NIGHTLY_BUILD" = "true" ]; then
+          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 7 nightly-$(date +%Y-%m-%d) results_backend_integration_open.xml
+          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 8 nightly-$(date +%Y-%m-%d) results_backend_integration_enterprise.xml
+        fi
 
-    - cp /var/log/sysstat/sysstat.log .
-    - sadf sysstat.log -g -- -qurbS > sysstat.svg
+        cp /var/log/sysstat/sysstat.log .
+        sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+        # Post job status
+        ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+      fi
 
   artifacts:
     expire_in: 2w
@@ -919,7 +930,12 @@ test_backend_integration:
     reports:
       junit: results_backend_integration_*.xml
 
-test_full_integration:
+test_backend_integration_open_source:
+  extends: test_backend_integration_enterprise
+  variables:
+    TEST_SUITE: "open"
+
+test_full_integration_enterprise:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
@@ -930,6 +946,7 @@ test_full_integration:
   variables:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
+    TEST_SUITE: "enterprise"
   tags:
     - mender-qa-slave-highmem
   needs:
@@ -953,9 +970,8 @@ test_full_integration:
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
-    # Post job status
+    # for Post job status
     - apk --update add curl jq sysstat docker-compose hdparm
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Start dockerd in the background
     - /usr/local/bin/dockerd &
@@ -1004,23 +1020,31 @@ test_full_integration:
       trap handle_exit EXIT
 
     - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
-    - echo Running integration tests suite $INTEGRATION_TEST_SUITE
-    # only do automatic test suite selection if the user wasn't specific
-    # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
-    - if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
-        case $INTEGRATION_TEST_SUITE in
-          "enterprise")
-            export SPECIFIC_INTEGRATION_TEST="Enterprise";;
-          "open")
-            export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
-        esac
-      fi
-    - source ${CI_PROJECT_DIR}/build_revisions.env
-    - cd integration/tests
-    - ./run.sh --no-download --machine-name qemux86-64
+    - >
+      if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
+        # Post job status
+        ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
-    # Always keep this at the end of the script stage
-    - echo "success" > /JOB_RESULT.txt
+        echo Running integration tests suite $INTEGRATION_TEST_SUITE
+        # only do automatic test suite selection if the user wasn't specific
+        # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
+        if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
+          case $INTEGRATION_TEST_SUITE in
+            "enterprise")
+              export SPECIFIC_INTEGRATION_TEST="Enterprise";;
+            "open")
+              export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
+          esac
+        fi
+        source ${CI_PROJECT_DIR}/build_revisions.env
+        cd integration/tests
+        ./run.sh --no-download --machine-name qemux86-64
+
+        # Always keep this at the end of the script stage
+        echo "success" > /JOB_RESULT.txt
+      else
+        echo "skipped" > /JOB_RESULT.txt
+      fi
 
     - ")"
 
@@ -1030,21 +1054,24 @@ test_full_integration:
     - unset DOCKER_CERT_PATH
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - >
+      if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
+        if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-    - cp -r ${CI_PROJECT_DIR}/../integration/tests/mender_test_logs .
-    - cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
-    - cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
+        cp -r ${CI_PROJECT_DIR}/../integration/tests/mender_test_logs .
+        cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
+        cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
 
-    - if [ "$NIGHTLY_BUILD" = "true" ]; then
-    -   ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 9 nightly-$(date +%Y-%m-%d) results_full_integration.xml
-    - fi
+        if [ "$NIGHTLY_BUILD" = "true" ]; then
+          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 9 nightly-$(date +%Y-%m-%d) results_full_integration.xml
+        fi
 
-    - cp /var/log/sysstat/sysstat.log .
-    - sadf sysstat.log -g -- -qurbS > sysstat.svg
+        cp /var/log/sysstat/sysstat.log .
+        sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+        # Post job status
+        ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+      fi
 
   artifacts:
     expire_in: 2w
@@ -1057,6 +1084,11 @@ test_full_integration:
       - sysstat.svg
     reports:
       junit: results_full_integration.xml
+
+test_full_integration_open_source:
+  extends: test_full_integration_enterprise
+  variables:
+    TEST_SUITE: "open"
 
 # Publish acceptance test coverage into coveralls when either running tests for a
 # mender PR (MENDER_REV ~= /pull/XXX/head/) or new merge into mender/master that requires


### PR DESCRIPTION
https://tracker.mender.io/browse/QA-168

`test_backend_integration` is separated on `test_backend_integration_enterprise` and `test_backend_integration_open`
`test_full_integration ` is separated on `test_full_integration_enterprise` and `test_full_integration_open`

[The pipeline](https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/217237501) was manually triggered for checking the changes.