### PR TITLE
Quick fix for staging builds: do not checkout OS repos

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,19 +223,27 @@ init_workspace:
     - checkout_repo INTEGRATION https://github.com/mendersoftware/integration integration $INTEGRATION_REV
     - checkout_repo META_MENDER https://github.com/mendersoftware/meta-mender meta-mender $META_MENDER_REV
     - checkout_repo MENDER https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender $MENDER_REV
-    - checkout_repo DEPLOYMENTS https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments $DEPLOYMENTS_REV
+    - if [ -n "$DEPLOYMENTS_REV" ]; then
+    -   checkout_repo DEPLOYMENTS https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments $DEPLOYMENTS_REV
+    - fi
     - checkout_repo DEPLOYMENTS_ENTERPRISE git@github.com:mendersoftware/deployments-enterprise go/src/github.com/mendersoftware/deployments-enterprise $DEPLOYMENTS_ENTERPRISE_REV
     - checkout_repo DEVICEAUTH https://github.com/mendersoftware/deviceauth go/src/github.com/mendersoftware/deviceauth $DEVICEAUTH_REV
     - checkout_repo GUI https://github.com/mendersoftware/gui gui $GUI_REV
-    - checkout_repo INVENTORY https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory $INVENTORY_REV
+    - if [ -n "$INVENTORY_REV" ]; then
+    -   checkout_repo INVENTORY https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory $INVENTORY_REV
+    - fi
     - checkout_repo INVENTORY_ENTERPRISE git@github.com:mendersoftware/inventory-enterprise.git go/src/github.com/mendersoftware/inventory-enterprise $INVENTORY_ENTERPRISE_REV
-    - checkout_repo USERADM https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm $USERADM_REV
+    - if [ -n "$USERADM_REV" ]; then
+    -   checkout_repo USERADM https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm $USERADM_REV
+    - fi
     - checkout_repo USERADM_ENTERPRISE git@github.com:mendersoftware/useradm-enterprise go/src/github.com/mendersoftware/useradm-enterprise $USERADM_ENTERPRISE_REV
     - checkout_repo MENDER_API_GATEWAY_DOCKER https://github.com/mendersoftware/mender-api-gateway-docker mender-api-gateway-docker $MENDER_API_GATEWAY_DOCKER_REV
     - checkout_repo MENDER_STRESS_TEST_CLIENT https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client $MENDER_STRESS_TEST_CLIENT_REV
     - checkout_repo MENDER_ARTIFACT https://github.com/mendersoftware/mender-artifact go/src/github.com/mendersoftware/mender-artifact $MENDER_ARTIFACT_REV
     - checkout_repo TENANTADM git@github.com:mendersoftware/tenantadm go/src/github.com/mendersoftware/tenantadm $TENANTADM_REV
-    - checkout_repo WORKFLOWS git@github.com:mendersoftware/workflows go/src/github.com/mendersoftware/workflows $WORKFLOWS_REV
+    - if [ -n "$WORKFLOWS_REV" ]; then
+    -   checkout_repo WORKFLOWS git@github.com:mendersoftware/workflows go/src/github.com/mendersoftware/workflows $WORKFLOWS_REV
+    - fi
     - checkout_repo WORKFLOWS_ENTERPRISE git@github.com:mendersoftware/workflows-enterprise go/src/github.com/mendersoftware/workflows-enterprise $WORKFLOWS_ENTERPRISE_REV
     - checkout_repo CREATE_ARTIFACT_WORKER git@github.com:mendersoftware/create-artifact-worker go/src/github.com/mendersoftware/create-artifact-worker $CREATE_ARTIFACT_WORKER_REV
     - checkout_repo META_OPENEMBEDDED git://git.openembedded.org/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV


### PR DESCRIPTION
These OS versions are empty when integration-test-bot launches PRs for
staging branches. It did silently "work" before (git checkout [empty]
exits 0) but not after the rework (arguments explicitly checked).

This commit introduces a quick fix (not maintainable) and a better one
should be put in place later.