### PR TITLE
Fix OS/Enterprise test selection in OS/Enterprise test jobs

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -446,55 +446,53 @@ test_backend_integration_enterprise:
 
     - INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
 
-    - >
-      if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
-        # Post job status
-        ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+    - if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
+    -   # Post job status
+    -   ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
-        echo Running backend-tests suite $INTEGRATION_TEST_SUITE
-        cd integration/backend-tests/
+    -   echo Running backend-tests suite $INTEGRATION_TEST_SUITE
+    -   cd integration/backend-tests/
 
-        # From 2.4.x on, the script would download the requirements by default
-        if ./run --help | grep -e --no-download; then
-          RUN_ARGS="--no-download";
-        fi
+    -   # From 2.4.x on, the script would download the requirements by default
+    -   if ./run --help | grep -e --no-download; then
+    -     RUN_ARGS="--no-download";
+    -   fi
 
-        # for pre 2.2.x releases, ignore test suite selection and just run open tests
-        if ./run --help | grep -e --suite; then
-          ./run --suite $TEST_SUITE $RUN_ARGS;
-        else
-          PYTEST_ARGS="-k 'not Multitenant'" ./run;
-        fi
+    -   # for pre 2.2.x releases, ignore test suite selection and just run open tests
+    -   if ./run --help | grep -e --suite; then
+    -     ./run --suite $TEST_SUITE $RUN_ARGS;
+    -   else
+    -     PYTEST_ARGS="-k 'not Multitenant'" ./run;
+    -   fi
 
-        # Always keep this at the end of the script stage
-        echo "success" > /JOB_RESULT.txt
-      else
-        echo "skipped" > /JOB_RESULT.txt
-      fi
+    -   # Always keep this at the end of the script stage
+    -   echo "success" > /JOB_RESULT.txt
+    - else
+    -   echo "skipped" > /JOB_RESULT.txt
+    - fi
 
     - ")"
 
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - >
-      if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
-        if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
+    -   if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-        find ${CI_PROJECT_DIR}/../integration/backend-tests -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec cp "{}" . \;
-        ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
-        ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
+    -   find ${CI_PROJECT_DIR}/../integration/backend-tests -mindepth 1 -maxdepth 1 -name 'acceptance.*' -exec cp "{}" . \;
+    -   ls ${CI_PROJECT_DIR}/../integration/backend-tests/results_*xml | xargs -n 1 -i cp {} .
+    -   ls ${CI_PROJECT_DIR}/../integration/backend-tests/report_*html | xargs -n 1 -i cp {} .
 
-        if [ "$NIGHTLY_BUILD" = "true" ]; then
-          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 7 nightly-$(date +%Y-%m-%d) results_backend_integration_open.xml
-          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 8 nightly-$(date +%Y-%m-%d) results_backend_integration_enterprise.xml
-        fi
+    -   if [ "$NIGHTLY_BUILD" = "true" ]; then
+    -     ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 7 nightly-$(date +%Y-%m-%d) results_backend_integration_open.xml
+    -     ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 8 nightly-$(date +%Y-%m-%d) results_backend_integration_enterprise.xml
+    -   fi
 
-        cp /var/log/sysstat/sysstat.log .
-        sadf sysstat.log -g -- -qurbS > sysstat.svg
+    -   cp /var/log/sysstat/sysstat.log .
+    -   sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-        # Post job status
-        ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
-      fi
+    -   # Post job status
+    -   ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+    - fi
 
   artifacts:
     expire_in: 2w
@@ -598,31 +596,30 @@ test_full_integration_enterprise:
       trap handle_exit EXIT
 
     - INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
-    - >
-      if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
-        # Post job status
-        ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+    - if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
+    -   # Post job status
+    -   ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
-        echo Running integration tests suite $INTEGRATION_TEST_SUITE
-        # only do automatic test suite selection if the user wasn't specific
-        # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
-        if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
-          case $TEST_SUITE in
-            "enterprise")
-              export SPECIFIC_INTEGRATION_TEST="Enterprise";;
-            "open")
-              export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
-          esac
-        fi
-        source ${CI_PROJECT_DIR}/build_revisions.env
-        cd integration/tests
-        ./run.sh --no-download --machine-name qemux86-64
+    -   echo Running integration tests suite $INTEGRATION_TEST_SUITE
+    -   # only do automatic test suite selection if the user wasn't specific
+    -   # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
+    -   if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
+    -     case $TEST_SUITE in
+    -       "enterprise")
+    -         export SPECIFIC_INTEGRATION_TEST="Enterprise";;
+    -       "open")
+    -         export SPECIFIC_INTEGRATION_TEST="not Enterprise";;
+    -     esac
+    -   fi
+    -   source ${CI_PROJECT_DIR}/build_revisions.env
+    -   cd integration/tests
+    -   ./run.sh --no-download --machine-name qemux86-64
 
-        # Always keep this at the end of the script stage
-        echo "success" > /JOB_RESULT.txt
-      else
-        echo "skipped" > /JOB_RESULT.txt
-      fi
+    -   # Always keep this at the end of the script stage
+    -   echo "success" > /JOB_RESULT.txt
+    - else
+    -   echo "skipped" > /JOB_RESULT.txt
+    - fi
 
     - ")"
 
@@ -632,24 +629,23 @@ test_full_integration_enterprise:
     - unset DOCKER_CERT_PATH
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - >
-      if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
-        if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - if [ "$(cat /JOB_RESULT.txt)" != "skipped" ]; then
+    -   if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
-        cp -r ${CI_PROJECT_DIR}/../integration/tests/mender_test_logs .
-        cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
-        cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
+    -   cp -r ${CI_PROJECT_DIR}/../integration/tests/mender_test_logs .
+    -   cp ${CI_PROJECT_DIR}/../integration/tests/results.xml results_full_integration.xml
+    -   cp ${CI_PROJECT_DIR}/../integration/tests/report.html report_full_integration.html
 
-        if [ "$NIGHTLY_BUILD" = "true" ]; then
-          ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 9 nightly-$(date +%Y-%m-%d) results_full_integration.xml
-        fi
+    -   if [ "$NIGHTLY_BUILD" = "true" ]; then
+    -     ${CI_PROJECT_DIR}/scripts/mantra_post_test_results 9 nightly-$(date +%Y-%m-%d) results_full_integration.xml
+    -   fi
 
-        cp /var/log/sysstat/sysstat.log .
-        sadf sysstat.log -g -- -qurbS > sysstat.svg
+    -   cp /var/log/sysstat/sysstat.log .
+    -   sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-        # Post job status
-        ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
-      fi
+    -   # Post job status
+    -   ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+    - fi
 
   artifacts:
     expire_in: 2w

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -461,7 +461,7 @@ test_backend_integration_enterprise:
 
         # for pre 2.2.x releases, ignore test suite selection and just run open tests
         if ./run --help | grep -e --suite; then
-          ./run --suite $INTEGRATION_TEST_SUITE $RUN_ARGS;
+          ./run --suite $TEST_SUITE $RUN_ARGS;
         else
           PYTEST_ARGS="-k 'not Multitenant'" ./run;
         fi
@@ -597,7 +597,7 @@ test_full_integration_enterprise:
       };
       trap handle_exit EXIT
 
-    - export INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
+    - INTEGRATION_TEST_SUITE=$(integration/extra/release_tool.py --select-test-suite || echo "all")
     - >
       if [ "$INTEGRATION_TEST_SUITE" = "$TEST_SUITE" ] || [ "$INTEGRATION_TEST_SUITE" = "all" ]; then
         # Post job status
@@ -607,7 +607,7 @@ test_full_integration_enterprise:
         # only do automatic test suite selection if the user wasn't specific
         # run.sh will pick up the SPECIFIC_INTEGRATION_TEST var
         if [ -z "$SPECIFIC_INTEGRATION_TEST" ]; then
-          case $INTEGRATION_TEST_SUITE in
+          case $TEST_SUITE in
             "enterprise")
               export SPECIFIC_INTEGRATION_TEST="Enterprise";;
             "open")


### PR DESCRIPTION
By using `TEST_SUITE` instead of `INTEGRATION_TEST_SUITE` when actually
calling (or preparing the call) to the wrappers.

Otherwise, all case where `release_tool.py` would select all, each job
actually runs all the tests (OS + Enterprise).

It is unknown if this has been broken since its implementation or after
a rework of the PR.