### PR TITLE
[build.yml] build_servers: Add missing jq dependency

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -48,7 +48,7 @@ build_servers:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
-    - apk --update add bash git make python3 py-pip curl
+    - apk --update add bash git make python3 py-pip curl jq
     - pip3 install pyyaml
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env


### PR DESCRIPTION
After 8cfc9dd the job manages to send the pending status, but still
fails on sending success/failure in after_script.