### PR TITLE
[build.yml] build_servers: Set result to sucess at scripts' end

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -62,6 +62,7 @@ build_servers:
     - tar -xf /tmp/workspace.tar.gz
   script:
     - ${WORKSPACE}/mender-qa/scripts/servers-build.sh
+    - echo "success" > /JOB_RESULT.txt
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi


### PR DESCRIPTION
This was missing from original split in 9bbc6b7, but hidden due to
missing dependencies fixed 8cfc9dd and 5ad5d18.