### PR TITLE
[publish.yml] QA-245: More strict conditions to publish coverage

### DIFF
--- a/gitlab-pipeline/stage/publish.yml
+++ b/gitlab-pipeline/stage/publish.yml
@@ -1,11 +1,11 @@
 
-# Publish acceptance test coverage into coveralls when either running tests for a
-# mender PR (MENDER_REV ~= /pull/XXX/head/) or new merge into mender/master that requires
-# Docker images publishing (PUBLISH_DOCKER_CLIENT_IMAGES == "true")
+# Publish acceptance test coverage into coveralls when either:
+# * running tests for a mender PR: MENDER_REV ~= /pull/XXX/head/
+# * new merge into master triggered a Docker images publishing: PUBLISH_DOCKER_CLIENT_IMAGES == "true"
 .template_publish_acceptance_coverage:
   only:
     variables:
-      - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"
+      - $PUBLISH_DOCKER_CLIENT_IMAGES == "true" && $MENDER_REV == "master" && $META_MENDER_REV == "master"
       - $MENDER_REV =~ /pull\/.*\/head/
   stage: publish
   needs:


### PR DESCRIPTION
Make sure we only publish the coverage when testing both mender client
and meta-mender are master, otherwise we risk publishing coverage for a
custom build from a PR intending to also publish the qemu image.

Commit 30d3053 wasn't enough...