### PR TITLE
QA-256: [gitlab_trigger_client_publish] Extend trigger to other repos

### DIFF
--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -2,6 +2,9 @@
 
 set -ex
 
+# Number of release branches to build when trigger comes from meta-mender
+NUMBER_OF_MINOR_VERSIONS=3
+
 if [[ $# -eq 2 ]]; then
   version_to_publish=$1
   trigger_from_repo=$2
@@ -14,7 +17,8 @@ else
   exit 1
 fi
 
-if ! grep "^${trigger_from_repo}\$" <<<$($WORKSPACE/integration/extra/release_tool.py --list git); then
+if ! grep "^${trigger_from_repo}\$" <<<$($WORKSPACE/integration/extra/release_tool.py --list git) \
+    && [ "$trigger_from_repo" != "meta-mender" ]; then
   echo "Unrecognized repository $trigger_from_repo" >&2
   exit 1
 fi
@@ -29,16 +33,29 @@ if [ ! -d $WORKSPACE/integration ]; then
   exit 1
 fi
 
+# Get the integration versions to publish
+if [ "$trigger_from_repo" == "meta-mender" ]; then
+  # Special handling on meta-mender: publish master + last three releases
+  cd $WORKSPACE/integration
+  remote=$(git config -l | \
+           sed -n -E 's|^remote\.([^.]+)\.url=.*github\.com[/:]mendersoftware/integration(\.git)?$|\1|p')
+  integration_versions=$(git for-each-ref --sort=-creatordate --format='%(refname:short)' 'refs/tags' | \
+                         sed -E '/(^[0-9]+\.[0-9]+)\.[0-9]+$/!d;s//\1.x/' | \
+                         uniq | \
+                         head -n $NUMBER_OF_MINOR_VERSIONS)
+  integration_versions="$remote/master $integration_versions"
+  cd -
+else
+  # Integration versions including trigger_from_repo/version_to_publish
+  integration_versions=$($WORKSPACE/integration/extra/release_tool.py \
+                        --integration-versions-including $trigger_from_repo \
+                        --version $version_to_publish)
+fi
 
-# For each integration version including trigger_from_repo/version_to_publish:
+# For each integration version to publish:
 # * construct a curl formatted string concatenating each repo and revision like:
 #   '-F variables[repoA_REV]=X.X.x -F variables[repoB_REV]=X.X.x ...'
 # * trigger a Mender QA pipeline to build/test/publish client
-
-integration_versions=$($WORKSPACE/integration/extra/release_tool.py \
-                       --integration-versions-including $trigger_from_repo \
-                       --version $version_to_publish)
-
 for integ_version in $integration_versions; do
 
   variables_revs=""

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -2,10 +2,20 @@
 
 set -ex
 
-mender_version=$1
+if [[ $# -eq 2 ]]; then
+  version_to_publish=$1
+  trigger_from_repo=$2
+elif [[ $# -eq 1 ]]; then
+  # Backwards compatibility
+  version_to_publish=$1
+  trigger_from_repo="mender"
+else
+  echo "Usage: $0 version repo" >&2
+  exit 1
+fi
 
-if [ -z "$mender_version" ]; then
-  echo "Usage: $0 mender-version"
+if ! grep "^${trigger_from_repo}\$" <<<$($WORKSPACE/integration/extra/release_tool.py --list git); then
+  echo "Unrecognized repository $trigger_from_repo" >&2
   exit 1
 fi
 
@@ -20,14 +30,14 @@ if [ ! -d $WORKSPACE/integration ]; then
 fi
 
 
-# For each integration version including mender version $mender_version:
+# For each integration version including trigger_from_repo/version_to_publish:
 # * construct a curl formatted string concatenating each repo and revision like:
 #   '-F variables[repoA_REV]=X.X.x -F variables[repoB_REV]=X.X.x ...'
 # * trigger a Mender QA pipeline to build/test/publish client
 
 integration_versions=$($WORKSPACE/integration/extra/release_tool.py \
-                       --integration-versions-including mender \
-                       --version $mender_version)
+                       --integration-versions-including $trigger_from_repo \
+                       --version $version_to_publish)
 
 for integ_version in $integration_versions; do
 

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -76,8 +76,10 @@ for integ_version in $integration_versions; do
     -F token=$MENDER_QA_TRIGGER_TOKEN \
     -F ref=master \
     -F variables[PUBLISH_DOCKER_CLIENT_IMAGES]=true \
-    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=true \
-    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=true \
+    -F variables[BUILD_CLIENT]=true \
+    -F variables[BUILD_SERVERS]=true \
+    -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=false \
+    -F variables[TEST_QEMUX86_64_UEFI_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[TEST_QEMUX86_64_BIOS_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB_GPT]=false \


### PR DESCRIPTION
* [gitlab_trigger_client_publish] Do not echo the trigger token
* QA-256: [gitlab_trigger_client_publish] Extend trigger to other repos
Accept triggers from mender, mender-artifact and mender-connect. If repo
is not passed, it assumes mender to keep compatibility with old mender
release branches.
* QA-256: [gitlab_trigger_client_publish] Accept trigger from meta-mender
For which we will publish master + last 2 stable releases.
*  [gitlab_trigger_client_publish] Skip acceptance tests
These triggers are coming from trusted branches, from which we have
already run acceptance tests on the PR that lead to the merge... So it
should be safe to skip the tests and save CI minutes here.