### PR TITLE
Move mender-client-docker build to its own pipeline job + misc

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -31,6 +31,50 @@ build_client:
       - sysstat.log
       - sysstat.svg
 
+build_client_docker:
+  stage: build
+  only:
+    variables:
+      - $BUILD_CLIENT == "true"
+      - $RUN_INTEGRATION_TESTS == "true"
+  needs:
+    - init_workspace
+  image: docker:19.03
+  services:
+    - docker:dind
+  tags:
+    - docker
+  before_script:
+    # Default value, will later be overwritten if successful
+    - echo "failure" > /JOB_RESULT.txt
+    # Dependencies
+    - apk --update add python3 py-pip curl jq
+    - pip3 install pyyaml
+    # Post job status
+    - source ${CI_PROJECT_DIR}/build_revisions.env
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+    # Prepare workspace
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+  script:
+    - docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-client-docker docker_url)
+    - cd go/src/github.com/mendersoftware/mender
+    - ./tests/build-docker -t $docker_url:pr
+    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    - docker save $docker_url:pr -o ${CI_PROJECT_DIR}/stage-artifacts/mender-client-docker.tar
+    - echo "success" > /JOB_RESULT.txt
+  after_script:
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+
+  artifacts:
+    expire_in: 2w
+    paths:
+      - stage-artifacts/
+
 build_servers:
   stage: build
   only:
@@ -69,7 +113,7 @@ build_servers:
 
     - mkdir -p stage-artifacts
     - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker`; do
-        if ! echo $repo | grep -q mender-client-qemu; then
+        if ! echo $repo | grep -q mender-client; then
           docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
           docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
         fi;
@@ -82,7 +126,6 @@ build_servers:
     expire_in: 2w
     paths:
       - stage-artifacts/
-
 
 build_mender-cli:
   stage: build

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -11,6 +11,7 @@
     - init_workspace
     - build_servers
     - build_client
+    - build_client_docker
   before_script:
     # Check correct dind setup
     - docker version
@@ -188,8 +189,8 @@ release_docker_images:automatic:client-only:
     - docker:19.03-dind
   dependencies:
     - init_workspace
-    - build_servers
     - build_client
+    - build_client_docker
   before_script:
     # Check correct dind setup
     - docker version

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -462,7 +462,7 @@ test_backend_integration_enterprise:
 
     # Load all docker images except client
     - for repo in `integration/extra/release_tool.py -l docker`; do
-        if ! echo $repo | grep -q mender-client-qemu; then
+        if ! echo $repo | grep -q mender-client; then
           docker load -i stage-artifacts/${repo}.tar;
         fi;
       done
@@ -589,6 +589,7 @@ test_full_integration_enterprise:
     - init_workspace
     - build_servers
     - build_client
+    - build_client_docker
     - build_mender-artifact
   before_script:
     # Default value, will later be overwritten if successful

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -77,7 +77,7 @@ for integ_version in $integration_versions; do
     -F ref=master \
     -F variables[PUBLISH_DOCKER_CLIENT_IMAGES]=true \
     -F variables[BUILD_CLIENT]=true \
-    -F variables[BUILD_SERVERS]=true \
+    -F variables[BUILD_SERVERS]=false \
     -F variables[BUILD_QEMUX86_64_UEFI_GRUB]=false \
     -F variables[TEST_QEMUX86_64_UEFI_GRUB]=false \
     -F variables[BUILD_QEMUX86_64_BIOS_GRUB]=false \

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -41,18 +41,12 @@ build_servers_repositories() {
                 ;;
 
             mender-client-docker)
-                # We build the docker-client here, as well as some support
-                # tools, but the Yocto based image is too expensive to build
-                # here, since this section is run by pure server builds as
-                # well. See the build_and_test_client function for that.
-                cd go/src/github.com/mendersoftware/mender
-
-                ./tests/build-docker -t $docker_url:pr
-                $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
+                # Built directly on an independent pipeline job
+                :
                 ;;
 
             mender-client-qemu*)
-                # Built in build_and_test_client.
+                # Built in yocto-build-and-test.sh::build_and_test_client
                 :
                 ;;
 

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -16,16 +16,15 @@ build_servers_repositories() {
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
 
         case "$docker" in
-            deployments|deployments-enterprise|deviceauth|inventory|inventory-enterprise|tenantadm|useradm|useradm-enterprise|workflows|workflows-enterprise|workflows-worker|workflows-enterprise-worker|create-artifact-worker|auditlogs|mtls-ambassador|deviceconnect|deviceconfig)
+            deployments|deployments-enterprise|deviceauth|inventory|inventory-enterprise|tenantadm|useradm|useradm-enterprise|workflows|workflows-enterprise|create-artifact-worker|auditlogs|mtls-ambassador|deviceconnect|deviceconfig)
                 cd go/src/github.com/mendersoftware/$git
-                # workflows repository builds two different Docker images:
-                # - workflows, from Dockerfile
-                # - workflows-worker, from Dockerfile.worker
-                if [ "$docker" = "workflows-worker" ] || [ "$docker" = "workflows-enterprise-worker" ]; then
-                    docker build -t $docker_url:pr -f Dockerfile.worker .
-                else
-                    docker build -t $docker_url:pr .
-                fi
+                docker build -t $docker_url:pr .
+                $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
+                ;;
+
+            workflows-worker|workflows-enterprise-worker)
+                cd go/src/github.com/mendersoftware/$git
+                docker build -t $docker_url:pr -f Dockerfile.worker .
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -50,8 +50,6 @@ build_servers_repositories() {
 
                 ./tests/build-docker -t $docker_url:pr
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
-
-                make prefix=$WORKSPACE/go bindir=/bin install-modules-gen
                 ;;
 
             mender-client-qemu*)


### PR DESCRIPTION
* servers-build.sh: remove make install-modules-gen
The generator script used by integration tests, directory-artifact-gen,
seems to be downloaded also from integration/tests/run.sh, so it
shouldn't be necessary here.

* servers-build.sh: split out workflows-worker to a different case
Removing the if/else clause. Just for the sake of simplicity.

* Move mender-client-docker build to its own pipeline job
Split out mender-client-docker build from servers-build.sh, so that it
can be built independently of the rest of the micro-services.
On the one hand it just does not belong there any more, while on the
other hand this allows gitlab_trigger_client_publish for even lighter
pipelines.
