### PR TITLE
MEN-4420: Yocto integration of mender-configure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 
 variables:
-  # Versions
+  # Versions of components used for integration tests
   MENDER_REV: "master"
   META_MENDER_REV: "master"
   POKY_REV: "dunfell"
@@ -30,8 +30,11 @@ variables:
   MTLS_AMBASSADOR_REV: "master"
   DEVICECONNECT_REV: "master"
   MENDER_CONNECT_REV: "master"
-  MENDER_BINARY_DELTA_VERSION: "latest"
   DEVICECONFIG_REV: "master"
+
+  # Versions of independent components
+  MENDER_BINARY_DELTA_VERSION: "latest"
+  MENDER_CONFIGURE_MODULE_VERSION: "latest"
 
   # Build stage
   BUILD_CLIENT: "true"

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -120,6 +120,7 @@ prepare_build_config() {
 
     local client_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender --in-integration-version HEAD)
     local mender_artifact_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-artifact --in-integration-version HEAD)
+    local mender_connect_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-connect --in-integration-version HEAD)
 
 
     local mender_binary_delta_version=$($WORKSPACE/mender-binary-delta/x86_64/mender-binary-delta --version | egrep -o '[0-9]+\.[0-9]+\.[0-9b]+(-build[0-9]+)?')
@@ -165,10 +166,10 @@ EOF
         cd $WORKSPACE/go/src/github.com/mendersoftware/mender-artifact && \
         git tag --points-at HEAD 2>/dev/null | egrep ^"$MENDER_ARTIFACT_REV"$ ) || \
         mender_artifact_on_exact_tag=
-    local mender_shell_on_exact_tag=$(test "$MENDER_CONNECT_REV" != "master" && \
+    local mender_connect_on_exact_tag=$(test "$MENDER_CONNECT_REV" != "master" && \
         cd $WORKSPACE/go/src/github.com/mendersoftware/mender-connect && \
         git tag --points-at HEAD 2>/dev/null | egrep ^"$MENDER_CONNECT_REV"$ ) || \
-        mender_shell_on_exact_tag=
+        mender_connect_on_exact_tag=
 
     # Setting these PREFERRED_VERSIONs doesn't influence which version we build,
     # since we are building the one that Jenkins has cloned, but it does
@@ -203,13 +204,13 @@ PREFERRED_VERSION_pn-mender-artifact-native = "$mender_artifact_version-git%"
 EOF
     fi
 
-    if [ -n "$mender_shell_on_exact_tag" ]; then
+    if [ -n "$mender_connect_on_exact_tag" ]; then
         cat >> $BUILDDIR/conf/local.conf <<EOF
-PREFERRED_VERSION_pn-mender-connect = "$mender_shell_on_exact_tag"
+PREFERRED_VERSION_pn-mender-connect = "$mender_connect_on_exact_tag"
 EOF
     else
         cat >> $BUILDDIR/conf/local.conf <<EOF
-PREFERRED_VERSION_pn-mender-connect = "$mender_shell_version-git%"
+PREFERRED_VERSION_pn-mender-connect = "$mender_connect_version-git%"
 EOF
     fi
 }

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -130,6 +130,12 @@ FILESEXTRAPATHS_prepend_pn-mender-binary-delta := "${WORKSPACE}/mender-binary-de
 PREFERRED_VERSION_pn-mender-binary-delta = "$mender_binary_delta_version"
 EOF
 
+    if [ "$MENDER_CONFIGURE_MODULE_VERSION" != "latest" ]; then
+        cat >> $BUILDDIR/conf/local.conf <<EOF
+PREFERRED_VERSION_pn-mender-configure = "$MENDER_CONFIGURE_MODULE_VERSION"
+EOF
+    fi
+
     # Assuming sumo or newer
     cat >> $BUILDDIR/conf/local.conf <<EOF
 # MEN-2948: Renamed mender recipe -> mender-client


### PR DESCRIPTION
And:

* yocto-build-and-test.sh: Fix (and rename) mender-connect version logic
Variable $mender_connect_version was missing. Once on it, rename all
the set of variables from mender-shell to mender-connect.