### PR TITLE
[test_full_integration] Clean-up pip packages install

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -607,8 +607,8 @@ test_full_integration_enterprise:
     - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
-    # for Post job status
-    - apk --update add curl jq sysstat docker-compose hdparm
+    # Dependencies for post job status and io stats
+    - apk --update add curl jq sysstat hdparm
 
     # Start dockerd in the background
     - /usr/local/bin/dockerd &
@@ -623,10 +623,10 @@ test_full_integration_enterprise:
 
     # Output storage io stats
     - df -h . | tail -1 | awk '{system("hdparm -tT "$1);}'
+
     # Get and install the integration test requirements
     - apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
-    - pip install  -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
-    - pip3 install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
+    - pip install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
     # Load all docker images
     - for repo in `integration/extra/release_tool.py -l docker`; do


### PR DESCRIPTION
Namely: remove docker-compose from apk install, so that we instead
install the docker-compose version specified in requirements.txt file.

Indirectly, this is hiding the "cryptography upgrade" issue, as the OS
package installs an older version of it and the subsequent call to pip
install will ignore this dependency.

Removed also the now obsolete pip/pip3 calls, as both are Python 3 in
today's Alpine Linux.

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>