### PR TITLE
QA-255: Do not build the client from source unneeded.

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -3,7 +3,6 @@ build_client:
   only:
     variables:
       - $BUILD_CLIENT == "true"
-      - $RUN_INTEGRATION_TESTS == "true"
   stage: build
   extends: .template_build_test_acc
   services:
@@ -36,7 +35,6 @@ build_client_docker:
   only:
     variables:
       - $BUILD_CLIENT == "true"
-      - $RUN_INTEGRATION_TESTS == "true"
   needs:
     - init_workspace
   image: docker:19.03

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -571,7 +571,7 @@ test_backend_integration_open_source:
   variables:
     TEST_SUITE: "open"
 
-test_full_integration_enterprise:
+test:integration:open_source:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
@@ -582,7 +582,7 @@ test_full_integration_enterprise:
   variables:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
-    TEST_SUITE: "enterprise"
+    TEST_SUITE: "open"
   tags:
     - mender-qa-slave-highmem
   needs:
@@ -731,7 +731,7 @@ test_full_integration_enterprise:
     reports:
       junit: results_full_integration.xml
 
-test_full_integration_open_source:
-  extends: test_full_integration_enterprise
+test:integration:enterprise:
+  extends: test:integration:open_source
   variables:
-    TEST_SUITE: "open"
+    TEST_SUITE: "enterprise"

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -427,14 +427,14 @@ test_accep_raspberrypi4:
     reports:
       junit: results_accep_raspberrypi4.xml
 
-test_backend_integration_enterprise:
+test:integration:open_source:backend:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
   stage: test
   image: docker/compose:alpine-1.27.4
   variables:
-    TEST_SUITE: "enterprise"
+    TEST_SUITE: "open"
   services:
     - docker:19.03-dind
   tags:
@@ -566,10 +566,10 @@ test_backend_integration_enterprise:
     reports:
       junit: results_backend_integration_*.xml
 
-test_backend_integration_open_source:
-  extends: test_backend_integration_enterprise
+test:integration:enterprise:backend:
+  extends: test:integration:open_source:backend
   variables:
-    TEST_SUITE: "open"
+    TEST_SUITE: "enterprise"
 
 test:integration:open_source:
   only:

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -427,7 +427,7 @@ test_accep_raspberrypi4:
     reports:
       junit: results_accep_raspberrypi4.xml
 
-test:integration:open_source:backend:
+test:backend-integration:open_source:
   only:
     variables:
       - $RUN_INTEGRATION_TESTS == "true"
@@ -566,15 +566,12 @@ test:integration:open_source:backend:
     reports:
       junit: results_backend_integration_*.xml
 
-test:integration:enterprise:backend:
-  extends: test:integration:open_source:backend
+test:backend-integration:enterprise:
+  extends: test:backend-integration:open_source
   variables:
     TEST_SUITE: "enterprise"
 
-test:integration:open_source:
-  only:
-    variables:
-      - $RUN_INTEGRATION_TESTS == "true"
+.integration_setup_template:
   stage: test
   # Integration tests depends on running ssh to containers, we're forced to
   # run dockerd on the same host.
@@ -585,12 +582,6 @@ test:integration:open_source:
     TEST_SUITE: "open"
   tags:
     - mender-qa-slave-highmem
-  needs:
-    - init_workspace
-    - build_servers
-    - build_client
-    - build_client_docker
-    - build_mender-artifact
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -628,17 +619,32 @@ test:integration:open_source:
     - apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
     - pip install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
-    # Load all docker images
+    # Load all docker images, and the client images depending on $BUILD_CLIENT
     - for repo in `integration/extra/release_tool.py -l docker`; do
-        docker load -i stage-artifacts/${repo}.tar;
-      done
+    -   if echo $repo | grep -q mender-client; then
+    -     if [ "${BUILD_CLIENT}" = "true" ]; then
+    -       docker load -i stage-artifacts/${repo}.tar;
+    -     else
+    -       continue
+    -     fi
+    -   fi
+    -   docker load -i stage-artifacts/${repo}.tar;
+    - done
+
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_HUB_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for repo in `integration/extra/release_tool.py -l docker`; do
-        integration/extra/release_tool.py --set-version-of $repo --version pr;
-      done
+    -   if echo $repo | grep -q mender-client; then
+    -       if [ "${BUILD_CLIENT}" = "true" ]; then
+    -         integration/extra/release_tool.py --set-version-of $repo --version pr;
+    -       else
+    -         continue
+    -       fi
+    -   fi
+    -   integration/extra/release_tool.py --set-version-of $repo --version pr;
+    - done
     # Other dependencies
     - install stage-artifacts/mender-artifact-linux /usr/local/bin/mender-artifact
     - make -C ${WORKSPACE}/go/src/github.com/mendersoftware/mender install-modules-gen
@@ -731,7 +737,41 @@ test:integration:open_source:
     reports:
       junit: results_full_integration.xml
 
-test:integration:enterprise:
-  extends: test:integration:open_source
+
+test:integration:source_client:open_source:
+  extends: .integration_setup_template
+  only:
+    variables:
+      - ( $RUN_INTEGRATION_TESTS == "true" && $BUILD_CLIENT == "true" )
+  needs:
+    - init_workspace
+    - build_servers
+    - build_client
+    - build_client_docker
+    - build_mender-artifact
+
+
+test:integration:source_client:enterprise:
+  extends: test:integration:source_client:open_source
+  variables:
+    TEST_SUITE: "enterprise"
+
+
+test:integration:prebuilt_client:open_source:
+  extends: .integration_setup_template
+  only:
+    variables:
+      - $RUN_INTEGRATION_TESTS == "true"
+  except:
+    variables:
+      - $BUILD_CLIENT == "true"
+  needs:
+    - init_workspace
+    - build_servers
+    - build_mender-artifact
+
+
+test:integration:prebuilt_client:enterprise:
+  extends: test:integration:prebuilt_client:open_source
   variables:
     TEST_SUITE: "enterprise"

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -423,7 +423,7 @@ build_and_test_client() {
 
             cd $WORKSPACE/meta-mender/tests/acceptance/
 
-            # check if can generate HTML report
+            # check if we can generate an HTML report
             local html_report_args="--html=report.html --self-contained-html"
             if ! $pip_cmd list|grep -e pytest-html >/dev/null 2>&1; then
                 html_report_args=""


### PR DESCRIPTION
* Make the `integration-tests-enterprise` inherit from `open-source` and not the other way around
* Switch to use the `macro:minor:micro`  syntax, instead of underlines
* Only build the client from source when `BUILD_CLIENT == true` <- This is basically the `mender-qa` part of QA-255

