### PR TITLE
Extend build:client:docker job to build new integration's device image

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -1,5 +1,5 @@
 
-build:client:
+build:client:qemu:
   only:
     variables:
       - $BUILD_CLIENT == "true"
@@ -59,11 +59,24 @@ build:client:docker:
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
   script:
+    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    # First build mender's repo Docker image
     - docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-client-docker docker_url)
     - cd go/src/github.com/mendersoftware/mender
     - ./tests/build-docker -t $docker_url:pr
-    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
     - docker save $docker_url:pr -o ${CI_PROJECT_DIR}/stage-artifacts/mender-client-docker.tar
+    # Then, if available, build integration's repo Docker image (Mender 2.7 and later)
+    - if $($WORKSPACE/integration/extra/release_tool.py -l docker | egrep -q '^mender-client-docker-addons$'); then
+    -   docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-client-docker-addons docker_url)
+    -   cd $WORKSPACE/integration/extra/mender-client-docker-addons
+    -   docker build
+        --build-arg MENDER_CLIENT_VERSION=$MENDER_REV
+        --build-arg MENDER_CONNECT_VERSION=$MENDER_CONNECT_REV
+        --tag $docker_url:pr
+        .
+    -   mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    -   docker save $docker_url:pr -o ${CI_PROJECT_DIR}/stage-artifacts/mender-client-docker-addons.tar
+    - fi
     - echo "success" > /JOB_RESULT.txt
   after_script:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -10,7 +10,7 @@
   dependencies:
     - init_workspace
     - build:servers
-    - build:client
+    - build:client:qemu
     - build:client:docker
   before_script:
     # Check correct dind setup
@@ -189,7 +189,7 @@ release_docker_images:automatic:client-only:
     - docker:19.03-dind
   dependencies:
     - init_workspace
-    - build:client
+    - build:client:qemu
     - build:client:docker
   before_script:
     # Check correct dind setup

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -746,7 +746,7 @@ test:integration:source_client:open_source:
   needs:
     - init_workspace
     - build:servers
-    - build:client
+    - build:client:qemu
     - build:client:docker
     - build:mender-artifact
 

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -40,7 +40,7 @@ build_servers_repositories() {
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
-            mender-client-docker)
+            mender-client-docker*)
                 # Built directly on an independent pipeline job
                 :
                 ;;


### PR DESCRIPTION
Extend build:client:docker job to build new integration's device image and append :qemu to the other client build job to clearly separate the two domains.

See https://github.com/mendersoftware/integration/pull/1216