### PR TITLE
Specify INTEGRATION_REV when pushing instead of trying to figure it out.

### DIFF
--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -36,7 +36,7 @@
     - fi
     # Load, tag and push Docker images
     - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker); do
-        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version HEAD);
+        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
         docker load -i stage-artifacts/${image}.tar;
         docker tag $docker_url:pr $docker_url:${version};
@@ -82,7 +82,7 @@ release_docker_images:automatic:
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
   script:
     # Publish boards artifacts and sdimg (when hw). Note that vexpress-qemu-flash is ignored
-    - client_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender --in-integration-version HEAD)
+    - client_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender --in-integration-version $INTEGRATION_REV)
     - for board_name in qemux86-64-uefi-grub vexpress-qemu qemux86-64-bios-grub-gpt qemux86-64-bios-grub
       vexpress-qemu-uboot-uefi-grub beagleboneblack raspberrypi3 raspberrypi4; do
         aws s3 cp stage-artifacts/${board_name}_release_1_${client_version}.mender
@@ -132,7 +132,7 @@ release_board_artifacts:automatic:
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
   script:
     # mender-cli
-    - mender_cli_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-cli --in-integration-version HEAD)
+    - mender_cli_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-cli --in-integration-version $INTEGRATION_REV)
     - echo "=== mender-cli $mender_cli_version ==="
     # We can simplify once mender-cli 1.2.0 is not supported
     - if grep -q build-multiplatform $WORKSPACE/go/src/github.com/mendersoftware/mender-cli/Makefile; then
@@ -153,7 +153,7 @@ release_board_artifacts:automatic:
           --key mender-cli/${mender_cli_version}/mender-cli;
       fi
     # mender-artifact
-    - mender_artifact_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-artifact --in-integration-version HEAD)
+    - mender_artifact_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-artifact --in-integration-version $INTEGRATION_REV)
     - echo "=== mender-artifact $mender_artifact_version ==="
     - for bin in mender-artifact-darwin mender-artifact-linux mender-artifact-windows.exe; do
         platform=${bin#mender-artifact-};
@@ -214,7 +214,7 @@ release_docker_images:automatic:client-only:
     - fi
     # Load, tag and push mender-client-* images
     - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | grep mender-client); do
-        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version HEAD);
+        version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
         docker load -i stage-artifacts/${image}.tar;
         docker tag $docker_url:pr $docker_url:${version};


### PR DESCRIPTION
It's actually impossible to figure it out when specifying only HEAD,
because if you just branched, master and x.x.x will be on the same
commit, and it's impossible to know which is which. Better to just
pass in the required information instead.

MEN-4593

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>