### PR TITLE
Introduce special variable for Docker building jobs.

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -10,6 +10,7 @@ build:client:qemu:
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
     ONLY_BUILD: "true"
+    BUILD_DOCKER_IMAGES: "true"
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -88,8 +88,25 @@ init_workspace:
     -   echo "export MENDER_QA_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env
     - )
 
-    # Add other repositories.
     - checkout_repo INTEGRATION https://github.com/mendersoftware/integration integration $INTEGRATION_REV
+
+    # Fetch all branches for integration. This is needed during the publish
+    # stage when we query versions using the release_tool. Other repositories
+    # should not need it.
+    - (
+    -   cd integration
+    #   Rename the branch we're on, so that it's not in the way for the
+    #   subsequent fetch. It's ok if this fails, it just means we're not on any
+    #   branch.
+    -   git branch -m temp-branch || true
+    #   Git trick: Fetch directly into our local branches instead of remote
+    #   branches.
+    -   git fetch -f origin 'refs/heads/*:refs/heads/*'
+    #   Get last remaining tags, if any.
+    -   git fetch --tags origin
+    - )
+
+    # Add other repositories.
     - checkout_repo META_MENDER https://github.com/mendersoftware/meta-mender meta-mender $META_MENDER_REV
     - checkout_repo MENDER https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender $MENDER_REV
     - checkout_repo DEPLOYMENTS https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments $DEPLOYMENTS_REV

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -12,13 +12,6 @@ declare -a CONFIG_DEVICE_TYPES
 
 export PATH=$PATH:$WORKSPACE/go/bin
 
-is_building_dockerized_board() {
-    local ret=0
-    is_building_board qemux86-64-uefi-grub \
-        || ret=$?
-    return $ret
-}
-
 is_building_board() {
     local ret=0
     local uc_board="$(tr [a-z-] [A-Z_] <<<$1)"
@@ -477,7 +470,7 @@ build_and_test_client() {
         fi
 
         # Build Docker image on build only job
-        if is_building_dockerized_board && ! is_testing_board $board_name; then
+        if ${BUILD_DOCKER_IMAGES:-false}; then
             cd $WORKSPACE/meta-mender/meta-mender-qemu
             if [ -x docker/build-docker ]; then
                 # New style.


### PR DESCRIPTION
Previously we relied on a messy combination of ONLY_BUILD and testing
for TEST_QEMUX86_64_UEFI_GRUB. This would break if you manually
started a job where BUILD was set and TEST wasn't.

The new variable BUILD_DOCKER_IMAGES is much more descriptive of what
will happen if it is true. We enable this in the docker-building job
only. I chose to keep ONLY_BUILD as well, since these two decisions
are, strictly speaking, independent, even though they are both enabled
in the same job.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>