### PR TITLE
[pipeline] Fix pyyalm version to 5.3.1

### DIFF
--- a/Documentation/test-suites-overview.md
+++ b/Documentation/test-suites-overview.md
@@ -84,7 +84,7 @@ cp mender-integration/extra/travis-testing/* tests/
 cp docs/* tests/
 # Build and copy the binary
 go build
-cp deviceauth /tests
+cp deviceauth tests/
 # Get and copy mender-artifact
 wget https://downloads.mender.io/mender-artifact/master/linux/mender-artifact
 chmod +x mender-artifact

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -47,7 +47,7 @@ build:client:docker:
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
     - apk --update add python3 py-pip curl jq bash
-    - pip3 install pyyaml
+    - pip3 install pyyaml==5.3.1
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
@@ -104,7 +104,7 @@ build:servers:
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
     - apk --update add bash git make python3 py-pip curl jq
-    - pip3 install pyyaml
+    - pip3 install pyyaml==5.3.1
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -16,7 +16,7 @@ init_workspace:
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update add git openssh bash python3 curl py3-pip jq
-    - pip3 install --upgrade pyyaml
+    - pip3 install --upgrade pyyaml==5.3.1
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -17,7 +17,7 @@
     - docker version
     # Install dependencies
     - apk --update add git python3 py3-pip
-    - pip3 install --upgrade pyyaml
+    - pip3 install pyyaml==5.3.1
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -71,7 +71,7 @@ release_docker_images:automatic:
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git python3 python3-pip
-    - pip3 install --upgrade pyyaml
+    - pip3 install pyyaml==5.3.1
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -121,7 +121,7 @@ release_board_artifacts:automatic:
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git python3 python3-pip
-    - pip3 install --upgrade pyyaml
+    - pip3 install pyyaml==5.3.1
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -196,7 +196,7 @@ release_docker_images:automatic:client-only:
     - docker version
     # Install dependencies
     - apk --update add git python3 py3-pip
-    - pip3 install --upgrade pyyaml
+    - pip3 install pyyaml==5.3.1
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -450,7 +450,7 @@ test:backend-integration:open_source:
     - docker version
     - apk --update add bash git py-pip gcc make python2-dev
       libc-dev libffi-dev openssl-dev python3 curl jq sysstat
-    - pip3 install pyyaml
+    - pip3 install pyyaml==5.3.1
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp


### PR DESCRIPTION
Latest version introduces dependency on gcc which is not present in some
jobs (like init_workspace).

We'll follow-up with a more future proof solution.