### PR TITLE
QA-284: Install PyYaml from the requirements.txt in /extra/integration

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -48,7 +48,8 @@ build:client:docker:
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
     - apk --update add python3 py-pip curl jq bash
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
@@ -105,7 +106,8 @@ build:servers:
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
     - apk --update add bash git make python3 py-pip curl jq
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Post job status
     - source ${CI_PROJECT_DIR}/build_revisions.env
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -16,8 +16,6 @@ init_workspace:
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update add git openssh bash python3 curl py3-pip jq
-    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
-    - pip3 install -r requirements.txt
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -16,7 +16,8 @@ init_workspace:
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update add git openssh bash python3 curl py3-pip jq
-    - pip3 install --upgrade pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -17,7 +17,8 @@
     - docker version
     # Install dependencies
     - apk --update add git python3 py3-pip
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -71,7 +72,8 @@ release_docker_images:automatic:
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git python3 python3-pip
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -121,7 +123,8 @@ release_board_artifacts:automatic:
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git python3 python3-pip
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp
@@ -196,7 +199,8 @@ release_docker_images:automatic:client-only:
     - docker version
     # Install dependencies
     - apk --update add git python3 py3-pip
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -450,7 +450,8 @@ test:backend-integration:open_source:
     - docker version
     - apk --update add bash git py-pip gcc make python2-dev
       libc-dev libffi-dev openssl-dev python3 curl jq sysstat
-    - pip3 install pyyaml==5.3.1
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp

--- a/scripts/jenkins-yoctobuild-init-script.sh
+++ b/scripts/jenkins-yoctobuild-init-script.sh
@@ -71,5 +71,5 @@ pip3 install pyyaml --upgrade
 # use sar from sysstat to render the result file (~/sysstat.log) manually
 apt_get -qy --force-yes install sysstat
 sudo sed -i 's/false/true/g' /etc/default/sysstat
-sudo service sysstat start 
+sudo service sysstat start
 sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &


### PR DESCRIPTION
The two extra commits are there, because I am not sure what `PyYaml` is used for in these two instances, can you confirm that it's safe to squash these two commits in with the first one?

Also, the paths will be changed to master, when this is verified to work, ofc.