### PR TITLE
QA-315 - trigger downstream assets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,7 @@ include:
   - local: '/gitlab-pipeline/stage/build.yml'
   - local: '/gitlab-pipeline/stage/test.yml'
   - local: '/gitlab-pipeline/stage/publish.yml'
+  - local: '/gitlab-pipeline/stage/trigger.yml'
   - local: '/gitlab-pipeline/stage/release.yml'
   - local: '/gitlab-pipeline/stage/post.yml'
 
@@ -115,6 +116,6 @@ stages:
   - build
   - test
   - publish
+  - trigger
   - release
   - .post
-

--- a/gitlab-pipeline/stage/publish.yml
+++ b/gitlab-pipeline/stage/publish.yml
@@ -141,3 +141,16 @@ publish:acceptance:raspberrypi4:
     - test:acceptance:raspberrypi4
   variables:
     JOB_BASE_NAME: raspberrypi4
+
+publish:mender-dist-packages:
+  stage: publish
+  rules:
+    - if: '$INTEGRATION_REV =~ /^[0-9]+\.[0-9]+\.[0-9]+(-build\d+)?$/'
+  variables:
+    MENDER_VERSION: $MENDER_REV
+    MENDER_CONNECT_VERSION: $MENDER_CONNECT_REV
+    MENDER_CONFIGURE_VERSION: $DEVICECONFIG_REV
+  trigger:
+    project: Northern.tech/Mender/mender-dist-packages
+    branch: master
+    strategy: depend

--- a/gitlab-pipeline/stage/trigger.yml
+++ b/gitlab-pipeline/stage/trigger.yml
@@ -1,0 +1,19 @@
+.trigger_template:
+  stage: trigger
+  rules:
+    - if: '$INTEGRATION_REV =~ /^[0-9]+\.[0-9]+\.[0-9]+(-build\d+)?$/'
+    # the following is to prevent an endless loop of qa pipelines caused by downstream pipelines
+    - if: '$CI_PIPELINE_SOURCE == "pipeline"'
+      when: never
+
+trigger:mender-convert:
+  extends: .trigger_template
+  variables:
+    MENDER_ARTIFACT_VERSION: $MENDER_ARTIFACT_REV
+    MENDER_CLIENT_VERSION: $MENDER_REV
+    MENDER_ADDON_CONNECT_VERSION: $MENDER_CONNECT_REV
+    MENDER_ADDON_CONFIGURE_VERSION: $DEVICECONFIG_REV
+  trigger:
+    project: Northern.tech/Mender/mender-convert
+    branch: master
+    strategy: depend

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -1,0 +1,106 @@
+import argparse
+import os, subprocess
+import tempfile
+import shutil
+import yaml
+
+
+def initWorkspace():
+    path = tempfile.mkdtemp()
+    subprocess.run(
+        ["git", "clone", "https://github.com/mendersoftware/integration.git", path],
+        capture_output=True,
+        check=True,
+    )
+    return path
+
+
+def generate(integration_repo, trigger_from_repo, version_to_publish, filename):
+    release_tool = os.path.join(integration_repo, "extra", "release_tool.py")
+    integration_versions = subprocess.run(
+        [
+            release_tool,
+            "--integration-versions-including",
+            trigger_from_repo,
+            "--version",
+            version_to_publish,
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+    stage_name = "trigger"
+    document = {
+        "stages": [stage_name],
+        "trigger:mender-qa": {
+            "stage": stage_name,
+            "trigger": {
+                "project": "Northern.tech/Mender/mender-qa",
+                "branch": "master",
+                "strategy": "depend",
+            },
+            "variables": {
+                "PUBLISH_DOCKER_CLIENT_IMAGES": "true",
+                "BUILD_CLIENT": "true",
+                "BUILD_SERVERS": "false",
+                "BUILD_QEMUX86_64_UEFI_GRUB": "false",
+                "TEST_QEMUX86_64_UEFI_GRUB": "false",
+                "BUILD_QEMUX86_64_BIOS_GRUB": "false",
+                "TEST_QEMUX86_64_BIOS_GRUB": "false",
+                "BUILD_QEMUX86_64_BIOS_GRUB_GPT": "false",
+                "TEST_QEMUX86_64_BIOS_GRUB_GPT": "false",
+                "BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB": "false",
+                "TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB": "false",
+                "BUILD_VEXPRESS_QEMU": "false",
+                "TEST_VEXPRESS_QEMU": "false",
+                "BUILD_VEXPRESS_QEMU_FLASH": "false",
+                "TEST_VEXPRESS_QEMU_FLASH": "false",
+                "BUILD_BEAGLEBONEBLACK": "false",
+                "TEST_BEAGLEBONEBLACK": "false",
+                "BUILD_RASPBERRYPI3": "false",
+                "TEST_RASPBERRYPI3": "false",
+                "RUN_INTEGRATION_TESTS": "false",
+            },
+        },
+    }
+
+    repos = {}
+    for integ_version in integration_versions.stdout.decode("utf-8").splitlines():
+        all_repos = subprocess.run(
+            [release_tool, "--list", "git"], capture_output=True, check=True
+        )
+        for repo in all_repos.stdout.decode("utf-8").splitlines():
+            repo_version = subprocess.run(
+                [
+                    release_tool,
+                    "--version-of",
+                    repo,
+                    "--in-integration-version",
+                    integ_version,
+                    "|",
+                    "cut",
+                    "-d/",
+                    "-f2",
+                ],
+                capture_output=True,
+            )
+            repos[repo.replace("-", "_").upper()] = (
+                repo_version.stdout.decode("utf-8") or "master"
+            )
+
+        for repo, version in repos.items():
+            document["trigger:mender-qa"]["variables"][f"{repo}_REV"] = version
+
+    with open(filename, "w") as f:
+        yaml.dump(document, f)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--trigger")
+    parser.add_argument("--version", default="master")
+    parser.add_argument("--filename", default="gitlab-ci-client-qemu-publish-job.yml")
+    args = parser.parse_args()
+    integration_repo = initWorkspace()
+    generate(integration_repo, args.trigger, args.version, args.filename)
+    shutil.rmtree(integration_repo)


### PR DESCRIPTION
Due to the limited dependency on variables that need passing in this pipeline, the gitlab triggers can be used as they are. For situations that need more complex steps to define the variable passing or more complex decisions for the trigger execution/ rules (e.g. that might be solved using a `script` section in the trigger job) a pipeline generating script is included. This closely resembles the `gitlab_trigger_client_publish` script, but makes use of the `release_tool` requirements of both `python` & `pyyaml` to ease the writing of the (child) pipeline.
 If any future downstream assets turn out to require more complex variable definition, it might be needed to go through such a job generating job too (some limitations in variable expansion through gitlab, listed [here](https://gitlab.com/gitlab-org/gitlab-runner/-/issues/1809) and [here](https://gitlab.com/gitlab-org/gitlab/-/issues/293674) might require us to do so sooner rather than later 😬).

triggering pipeline is [here](https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines/314934728)
triggered pipelines are:
- [mender-binary-delta](https://gitlab.com/Northern.tech/Mender/mender-binary-delta/-/pipelines/315067058)
- [mender-connect](https://gitlab.com/Northern.tech/Mender/mender-connect/-/pipelines/315067091)
- [mender-convert](https://gitlab.com/Northern.tech/Mender/mender-convert/-/pipelines/315067062)

this relates to:
 - mendersoftware/mender#787 (job generation script location needs to be adjusted after merge)
 - mendersoftware/mender-connect#32 (job generation script location needs to be adjusted after merge)