### PR TITLE
gitlab_trigger_client_publish: Fix versions strings for meta-mender

### DIFF
--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -43,7 +43,7 @@ if [ "$trigger_from_repo" == "meta-mender" ]; then
                          sed -E '/(^[0-9]+\.[0-9]+)\.[0-9]+$/!d;s//\1.x/' | \
                          uniq | \
                          head -n $NUMBER_OF_MINOR_VERSIONS)
-  integration_versions="$remote/master $integration_versions"
+  integration_versions="$remote/master $(printf "$remote/%s " $integration_versions)"
   cd -
 else
   # Integration versions including trigger_from_repo/version_to_publish


### PR DESCRIPTION
The script was only working for master (i.e. $remote/master) and failing
when querying versions for every other integration version. It has
probably been broken since the last big refactor, as the error is hidden
in CI script (script returned 0 regardless).

Signed-off-by: Lluis Campos <lluis.campos@northern.tech>