### PR TITLE
MEN-4712: Integrate monitor-client

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,6 +32,7 @@ variables:
   MENDER_CONNECT_REV: "master"
   DEVICECONFIG_REV: "master"
   DEVICEMONITOR_REV: "master"
+  MONITOR_CLIENT_REV: "master"
 
   # Versions of independent components
   MENDER_BINARY_DELTA_VERSION: "latest"

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -18,6 +18,9 @@ build:client:qemu:
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
+    - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
+    -   docker save mendersoftware/mender-monitor-qemu-commercial:pr -o stage-artifacts/mender-monitor-qemu-commercial.tar
+    - fi
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -126,12 +129,12 @@ build:servers:
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - mkdir -p stage-artifacts
-    - for repo in `${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker`; do
-        if ! echo $repo | grep -q mender-client; then
-          docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $repo docker_url);
-          docker save $docker_url:pr -o stage-artifacts/${repo}.tar;
-        fi;
-      done
+    - for image in $(${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker); do
+    -   if ! echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -     docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $image docker_url)
+    -     docker save $docker_url:pr -o stage-artifacts/${image}.tar
+    -   fi
+    - done
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -134,6 +134,7 @@ init_workspace:
     - checkout_repo MENDER_CONNECT https://github.com/mendersoftware/mender-connect go/src/github.com/mendersoftware/mender-connect $MENDER_CONNECT_REV
     - checkout_repo DEVICECONFIG https://github.com/mendersoftware/deviceconfig go/src/github.com/mendersoftware/deviceconfig $DEVICECONFIG_REV
     - checkout_repo DEVICEMONITOR git@github.com:mendersoftware/devicemonitor go/src/github.com/mendersoftware/devicemonitor $DEVICEMONITOR_REV
+    - checkout_repo MONITOR_CLIENT git@github.com:mendersoftware/monitor-client monitor-client $MONITOR_CLIENT_REV
 
     # Print for debug purposes
     - cat ${CI_PROJECT_DIR}/build_revisions.env

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -217,7 +217,7 @@ release_docker_images:automatic:client-only:
     -   VERSION_TYPE_PARAMS="--version-type docker"
     - fi
     # Load, tag and push mender-client-* images
-    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | grep mender-client); do
+    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-monitor'); do
         version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
         docker load -i stage-artifacts/${image}.tar;

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -462,11 +462,11 @@ test:backend-integration:open_source:
     - mv /tmp/build_revisions.env /tmp/stage-artifacts .
 
     # Load all docker images except client
-    - for repo in `integration/extra/release_tool.py -l docker`; do
-        if ! echo $repo | grep -q mender-client; then
-          docker load -i stage-artifacts/${repo}.tar;
-        fi;
-      done
+    - for image in $(integration/extra/release_tool.py -l docker); do
+    -   if ! echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -     docker load -i stage-artifacts/${image}.tar
+    -   fi
+    - done
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_HUB_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
@@ -621,30 +621,30 @@ test:backend-integration:enterprise:
     - pip install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
     # Load all docker images, and the client images depending on $BUILD_CLIENT
-    - for repo in `integration/extra/release_tool.py -l docker`; do
-    -   if echo $repo | grep -q mender-client; then
+    - for image in $(integration/extra/release_tool.py -l docker); do
+    -   if echo $image | egrep -q 'mender-client|mender-monitor'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
-    -       docker load -i stage-artifacts/${repo}.tar;
+    -       docker load -i stage-artifacts/${image}.tar
     -     else
     -       continue
     -     fi
     -   fi
-    -   docker load -i stage-artifacts/${repo}.tar;
+    -   docker load -i stage-artifacts/${image}.tar
     - done
 
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_HUB_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
-    - for repo in `integration/extra/release_tool.py -l docker`; do
-    -   if echo $repo | grep -q mender-client; then
-    -       if [ "${BUILD_CLIENT}" = "true" ]; then
-    -         integration/extra/release_tool.py --set-version-of $repo --version pr;
-    -       else
-    -         continue
-    -       fi
+    - for image in $(integration/extra/release_tool.py -l docker); do
+    -   if echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -     if [ "${BUILD_CLIENT}" = "true" ]; then
+    -       integration/extra/release_tool.py --set-version-of $image --version pr
+    -     else
+    -       continue
+    -     fi
     -   fi
-    -   integration/extra/release_tool.py --set-version-of $repo --version pr;
+    -   integration/extra/release_tool.py --set-version-of $image --version pr
     - done
     # Other dependencies
     - install stage-artifacts/mender-artifact-linux /usr/local/bin/mender-artifact

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -50,6 +50,11 @@ build_servers_repositories() {
                 :
                 ;;
 
+            mender-monitor-qemu-commercial)
+                # Built in yocto-build-and-test.sh::build_and_test_client
+                :
+                ;;
+
             api-gateway)
                 cd $git
                 docker build -t $docker_url:pr .

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -367,13 +367,34 @@ build_and_test_client() {
         prepare_build_config $machine_name $board_name
 
         cd $BUILDDIR
+
+        # Base image
         bitbake $image_name
+        if ${BUILD_DOCKER_IMAGES:-false}; then
+            $WORKSPACE/meta-mender/meta-mender-qemu/docker/build-docker \
+                $machine_name \
+                -t mendersoftware/mender-client-qemu:pr
+            $WORKSPACE/integration/extra/release_tool.py \
+                --set-version-of mender-client-qemu \
+                --version pr
+        fi
 
         # Check if there is a R/O rootfs recipe available.
         if [[ $image_name == core-image-full-cmdline ]] \
                && [[ -f $WORKSPACE/meta-mender/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb ]]; then
-
             bitbake mender-image-full-cmdline-rofs
+            if ${BUILD_DOCKER_IMAGES:-false}; then
+                $WORKSPACE/meta-mender/meta-mender-qemu/docker/build-docker \
+                    -i mender-image-full-cmdline-rofs \
+                    $machine_name \
+                    -t mendersoftware/mender-client-qemu-rofs:pr
+                # It's ok if the next step fails, it just means we are
+                # testing a version of integration that neither has a rofs
+                # image, nor any tests for it.
+                $WORKSPACE/integration/extra/release_tool.py \
+                    --set-version-of mender-client-qemu-rofs \
+                    --version pr || true
+            fi
         fi
 
         # Check if there is a mender-monitor image recipe available.
@@ -381,6 +402,18 @@ build_and_test_client() {
                && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
             bitbake-layers add-layer $WORKSPACE/meta-mender/meta-mender-commercial
             bitbake mender-monitor-image-full-cmdline
+            if ${BUILD_DOCKER_IMAGES:-false}; then
+                $WORKSPACE/meta-mender/meta-mender-qemu/docker/build-docker \
+                    -i mender-monitor-image-full-cmdline \
+                    $machine_name \
+                    -t mendersoftware/mender-monitor-qemu-commercial:pr
+                # It's ok if the next step fails, it just means we are
+                # testing a version of integration that neither has a monitor
+                # image, nor any tests for it.
+                $WORKSPACE/integration/extra/release_tool.py \
+                    --set-version-of mender-monitor-qemu-commercial \
+                    --version pr || true
+            fi
             bitbake-layers remove-layer $WORKSPACE/meta-mender/meta-mender-commercial
         fi
 
@@ -485,45 +518,6 @@ build_and_test_client() {
             if is_hardware_board $board_name; then
                 gzip -c $WORKSPACE/$board_name/$image_name-$device_type.sdimg > $WORKSPACE/$board_name/mender-${board_name}_${client_version}.sdimg.gz
             fi
-        fi
-
-        # Build Docker image on build only job
-        if ${BUILD_DOCKER_IMAGES:-false}; then
-            cd $WORKSPACE/meta-mender/meta-mender-qemu
-            if [ -x docker/build-docker ]; then
-                # New style.
-                cd docker
-                ./build-docker $machine_name -t mendersoftware/mender-client-qemu:pr
-
-                # Check if there is a R/O rootfs recipe available.
-                if [[ -f $WORKSPACE/meta-mender/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb ]]; then
-                    ./build-docker -i mender-image-full-cmdline-rofs $machine_name -t mendersoftware/mender-client-qemu-rofs:pr
-                    # It's ok if the next step fails, it just means we are
-                    # testing a version of integration that neither has a rofs
-                    # image, nor any tests for it.
-                    $WORKSPACE/integration/extra/release_tool.py --set-version-of mender-client-qemu-rofs --version pr || true
-                fi
-
-                # Check if there is a Monitor recipe available.
-                if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
-                    ( cd $BUILDDIR && bitbake-layers add-layer $WORKSPACE/meta-mender/meta-mender-commercial )
-                    ./build-docker -i mender-monitor-image-full-cmdline $machine_name -t mendersoftware/mender-monitor-qemu-commercial:pr
-                    ( cd $BUILDDIR && bitbake-layers remove-layer $WORKSPACE/meta-mender/meta-mender-commercial )
-                    # It's ok if the next step fails, it just means we are
-                    # testing a version of integration that neither has a monitor
-                    # image, nor any tests for it.
-                    $WORKSPACE/integration/extra/release_tool.py --set-version-of mender-monitor-qemu-commercial --version pr || true
-                fi
-
-            elif is_building_board vexpress-qemu; then
-                # Old style.
-                cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/core-image-full-cmdline-vexpress-qemu.{ext4,sdimg} .
-                cp $BUILDDIR/tmp/deploy/images/vexpress-qemu/u-boot.elf .
-
-                docker build -t mendersoftware/mender-client-qemu:pr --build-arg VEXPRESS_IMAGE=core-image-full-cmdline-vexpress-qemu.sdimg --build-arg UBOOT_ELF=u-boot.elf .
-            fi
-
-            $WORKSPACE/integration/extra/release_tool.py --set-version-of mender-client-qemu --version pr
         fi
     )
 }


### PR DESCRIPTION
For now, hard-code the preferred version to "master-git", as we have
only one dev recipe which accepts any version. We'll rework this in a
later task, and then we can make mender-qa smarter.

Modified the release_tool for loops syntax for consistency.