### PR TITLE
generate_client_publish_job.py: misc extensions

### DIFF
--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -100,10 +100,14 @@ def generate(integration_repo, args):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--trigger", required=True)
+    parser.add_argument("--workspace", default=None)
     parser.add_argument("--version", default="master")
     parser.add_argument("--meta-mender-version", default="master")
     parser.add_argument("--filename", default="gitlab-ci-client-qemu-publish-job.yml")
     args = parser.parse_args()
-    integration_repo = initWorkspace()
-    generate(integration_repo, args)
-    shutil.rmtree(integration_repo)
+    if args.workspace:
+        generate(args.workspace, args)
+    else:
+        integration_repo = initWorkspace()
+        generate(integration_repo, args)
+        shutil.rmtree(integration_repo)

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -15,15 +15,15 @@ def initWorkspace():
     return path
 
 
-def generate(integration_repo, trigger_from_repo, version_to_publish, filename):
+def generate(integration_repo, args):
     release_tool = os.path.join(integration_repo, "extra", "release_tool.py")
     integration_versions = subprocess.run(
         [
             release_tool,
             "--integration-versions-including",
-            trigger_from_repo,
+            args.trigger,
             "--version",
-            version_to_publish,
+            args.version,
         ],
         capture_output=True,
         check=True,
@@ -88,10 +88,12 @@ def generate(integration_repo, trigger_from_repo, version_to_publish, filename):
                 repo_version.stdout.decode("utf-8") or "master"
             )
 
+        repos["META_MENDER"] = args.meta_mender_version
+
         for repo, version in repos.items():
             document["trigger:mender-qa"]["variables"][f"{repo}_REV"] = version
 
-    with open(filename, "w") as f:
+    with open(args.filename, "w") as f:
         yaml.dump(document, f)
 
 
@@ -99,8 +101,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--trigger", required=True)
     parser.add_argument("--version", default="master")
+    parser.add_argument("--meta-mender-version", default="master")
     parser.add_argument("--filename", default="gitlab-ci-client-qemu-publish-job.yml")
     args = parser.parse_args()
     integration_repo = initWorkspace()
-    generate(integration_repo, args.trigger, args.version, args.filename)
+    generate(integration_repo, args)
     shutil.rmtree(integration_repo)

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -97,7 +97,7 @@ def generate(integration_repo, trigger_from_repo, version_to_publish, filename):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("--trigger")
+    parser.add_argument("--trigger", required=True)
     parser.add_argument("--version", default="master")
     parser.add_argument("--filename", default="gitlab-ci-client-qemu-publish-job.yml")
     args = parser.parse_args()


### PR DESCRIPTION
* generate_client_publish_job.py: Mark argument --trigger as required
Without this argument, the script will crash.

* generate_client_publish_job.py: Add argument --meta-mender-version
This component is not part of the release tool, and for some special
builds we might need to set it.
Modified the interface of `generate` to pass directly the args object.

* generate_client_publish_job.py: New argument --workspace
To use an existing workspace instead of a fresh one from master. Useful
on advance use cases where for example integration shall be on a feature
branch.