### PR TITLE
generate_client_publish_job.py: fixes and extension

### DIFF
--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -77,15 +77,12 @@ def generate(integration_repo, args):
                     repo,
                     "--in-integration-version",
                     integ_version,
-                    "|",
-                    "cut",
-                    "-d/",
-                    "-f2",
                 ],
                 capture_output=True,
+                check=True,
             )
             repos[repo.replace("-", "_").upper()] = (
-                repo_version.stdout.decode("utf-8") or "master"
+                repo_version.stdout.decode("utf-8").rstrip().split("/")[1]
             )
 
         repos["META_MENDER"] = args.meta_mender_version

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -17,16 +17,17 @@ def initWorkspace():
 
 def generate(integration_repo, args):
     release_tool = os.path.join(integration_repo, "extra", "release_tool.py")
+    release_tool_args = [
+        release_tool,
+        "--integration-versions-including",
+        args.trigger,
+        "--version",
+        args.version,
+    ]
+    if args.feature_branches:
+        release_tool_args.append("--feature-branches")
     integration_versions = subprocess.run(
-        [
-            release_tool,
-            "--integration-versions-including",
-            args.trigger,
-            "--version",
-            args.version,
-        ],
-        capture_output=True,
-        check=True,
+        release_tool_args, capture_output=True, check=True,
     )
 
     # Filter out saas-* versions
@@ -109,6 +110,7 @@ if __name__ == "__main__":
     parser.add_argument("--workspace", default=None)
     parser.add_argument("--version", default="master")
     parser.add_argument("--meta-mender-version", default="master")
+    parser.add_argument("--feature-branches", action="store_true")
     parser.add_argument("--filename", default="gitlab-ci-client-qemu-publish-job.yml")
     args = parser.parse_args()
     if args.workspace:

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -29,6 +29,15 @@ def generate(integration_repo, args):
         check=True,
     )
 
+    # Filter out saas-* versions
+    # Historically, there have been some saas- releases using "master" of independent components
+    # (namely: mender-connect), but we certainly don't wont these versions in the generated jobs
+    integration_versions_list = [
+        ver
+        for ver in integration_versions.stdout.decode("utf-8").splitlines()
+        if not ver.startswith("saas-")
+    ]
+
     stage_name = "trigger"
     document = {
         "stages": [stage_name],
@@ -65,7 +74,7 @@ def generate(integration_repo, args):
     }
 
     repos = {}
-    for integ_version in integration_versions.stdout.decode("utf-8").splitlines():
+    for integ_version in integration_versions_list:
         all_repos = subprocess.run(
             [release_tool, "--list", "git"], capture_output=True, check=True
         )


### PR DESCRIPTION
* generate_client_publish_job.py: Fix parsing of --version-of calls
    
    Basically, the "| cut ..." was being passed to release_tool as regular
    arguments (and being ignored by it) rather than used in a shell.
    
    Move the post-processing to Python and remove the fallback "or master"
    so that we break the script on unexpected output.

* generate_client_publish_job.py: Add workaround to filter saas- versions

* generate_client_publish_job.py: Add argument --feature-branches
    
    To pass such a flag to release_tool in cases where we want to
    build/publish feature branches.
