### PR TITLE
MEN-4807: mender-monitor Yocto external flow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -102,6 +102,7 @@ include:
   - local: '/gitlab-pipeline/shared/build_and_test_acceptance.yml'
   - local: '/gitlab-pipeline/stage/pre.yml'
   - local: '/gitlab-pipeline/stage/init.yml'
+  - local: '/gitlab-pipeline/stage/init-mender-monitor-package.yml'
   - local: '/gitlab-pipeline/stage/build.yml'
   - local: '/gitlab-pipeline/stage/test.yml'
   - local: '/gitlab-pipeline/stage/publish.yml'

--- a/Documentation/adding-new-repository.md
+++ b/Documentation/adding-new-repository.md
@@ -112,7 +112,7 @@ Set a weekly schedule to build master pipeline for every Tuesday evening, at 9 P
 1. Modify Mender QA Pipeline:
   * ref https://github.com/mendersoftware/mender-qa/blob/master/.gitlab-ci.yml
   * Add new repo into `variables`
-  * Add new call to `checkout_repo` in `init_workspace`.
+  * Add new call to `checkout_repo` in `init:workspace`.
     * For private repositories, use ssh Git url
 2. Modify `servers-build.sh`
   * ref https://github.com/mendersoftware/mender-qa/blob/master/scripts/servers-build.sh

--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -2,7 +2,7 @@
 .template_build_test_acc:
   image: mendersoftware/mender-test-containers:mender-client-acceptance-testing
   needs:
-    - init_workspace
+    - init:workspace
   tags:
     - mender-qa-slave-highcpu
   before_script:

--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -3,6 +3,7 @@
   image: mendersoftware/mender-test-containers:mender-client-acceptance-testing
   needs:
     - init:workspace
+    - init:mender-monitor-package
   tags:
     - mender-qa-slave-highcpu
   before_script:
@@ -28,11 +29,12 @@
   script:
     # Traps only work if executed in a sub shell.
     - "("
-    - mv workspace.tar.gz /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
     - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/stage-artifacts .
 
     - function handle_exit() {
       if test -n "$ONLY_BUILD"; then

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -40,7 +40,7 @@ build:client:docker:
     variables:
       - $BUILD_CLIENT == "true"
   needs:
-    - init_workspace
+    - init:workspace
   image: docker:19.03
   services:
     - docker:dind
@@ -98,7 +98,7 @@ build:servers:
       - $BUILD_SERVERS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
   needs:
-    - init_workspace
+    - init:workspace
   image: docker
   services:
     - docker:19.03-dind
@@ -152,7 +152,7 @@ build:mender-cli:
       - $RUN_INTEGRATION_TESTS == "true"
   image: golang:1.15-alpine3.12
   needs:
-    - init_workspace
+    - init:workspace
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -208,7 +208,7 @@ build:mender-artifact:
   tags:
     - docker
   needs:
-    - init_workspace
+    - init:workspace
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt

--- a/gitlab-pipeline/stage/init-mender-monitor-package.yml
+++ b/gitlab-pipeline/stage/init-mender-monitor-package.yml
@@ -1,0 +1,27 @@
+init:mender-monitor-package:
+  stage: init
+  image: alpine:3.12
+  before_script:
+    - apk add --no-cache git openssh
+    # Prepare SSH keys
+    - eval $(ssh-agent -s)
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan github.com >> ~/.ssh/known_hosts
+    # Clone monitor-client
+    - git clone git@github.com:mendersoftware/monitor-client monitor-client
+    - cd monitor-client
+    - ( git fetch -u -f origin $MONITOR_CLIENT_REV:pr &&
+          git checkout pr ||
+          git checkout -f -b pr $MONITOR_CLIENT_REV
+      ) || return 1
+  script:
+    - apk add --no-cache make git
+    - git fetch --tags origin
+    - make package
+    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    - mv mender-monitor-*.tar.gz ${CI_PROJECT_DIR}/stage-artifacts
+  artifacts:
+    paths:
+      - stage-artifacts

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -1,5 +1,5 @@
 
-init_workspace:
+init:workspace:
   stage: init
   image: alpine:3.12
   script:

--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -33,7 +33,7 @@ coveralls:finish-build:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
   image: appropriate/curl
   dependencies:
-    - init_workspace
+    - init:workspace
   before_script:
     - apk --update add git
     # Get mender source

--- a/gitlab-pipeline/stage/publish.yml
+++ b/gitlab-pipeline/stage/publish.yml
@@ -9,7 +9,7 @@
       - $NIGHTLY_BUILD == "true"
   stage: publish
   needs:
-    - init_workspace
+    - init:workspace
   image: golang:1.15-alpine3.12
   before_script:
     - apk --update add git
@@ -49,7 +49,7 @@ publish:acceptance:qemux86_64:uefi_grub:
     variables:
       - $TEST_QEMUX86_64_UEFI_GRUB != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:qemux86_64:uefi_grub
   variables:
     JOB_BASE_NAME: qemux86_64_uefi_grub
@@ -60,7 +60,7 @@ publish:acceptance:vexpress_qemu:
     variables:
       - $TEST_VEXPRESS_QEMU != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:vexpress_qemu
   variables:
     JOB_BASE_NAME: vexpress_qemu
@@ -71,7 +71,7 @@ publish:acceptance:qemux86_64:bios_grub:
     variables:
       - $TEST_QEMUX86_64_BIOS_GRUB != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:qemux86_64:bios_grub
   variables:
     JOB_BASE_NAME: qemux86_64_bios_grub
@@ -82,7 +82,7 @@ publish:acceptance:qemux86_64:bios_grub_gpt:
     variables:
       - $TEST_QEMUX86_64_BIOS_GRUB_GPT != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:qemux86_64:bios_grub_gpt
   variables:
     JOB_BASE_NAME: qemux86_64_bios_grub_gpt
@@ -93,7 +93,7 @@ publish:acceptance:vexpress_qemu:uboot_uefi_grub:
     variables:
       - $TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:vexpress_qemu:uboot_uefi_grub
   variables:
     JOB_BASE_NAME: vexpress_qemu_uboot_uefi_grub
@@ -104,7 +104,7 @@ publish:acceptance:vexpress_qemu_flash:
     variables:
       - $TEST_VEXPRESS_QEMU_FLASH != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:vexpress_qemu_flash
   variables:
     JOB_BASE_NAME: vexpress_qemu_flash
@@ -115,7 +115,7 @@ publish:acceptance:beagleboneblack:
     variables:
       - $TEST_BEAGLEBONEBLACK != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:beagleboneblack
   variables:
     JOB_BASE_NAME: beagleboneblack
@@ -126,7 +126,7 @@ publish:acceptance:raspberrypi3:
     variables:
       - $TEST_RASPBERRYPI3 != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:raspberrypi3
   variables:
     JOB_BASE_NAME: raspberrypi3
@@ -137,7 +137,7 @@ publish:acceptance:raspberrypi4:
     variables:
       - $TEST_RASPBERRYPI4 != "true"
   needs:
-    - init_workspace
+    - init:workspace
     - test:acceptance:raspberrypi4
   variables:
     JOB_BASE_NAME: raspberrypi4

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -178,6 +178,44 @@ release_binary_tools:automatic:
       - $PUBLISH_RELEASE_AUTOMATIC == "true"
   extends: .template_release_binary_tools
 
+.template_release_mender-monitor:
+  stage: release
+  image: debian:buster
+  variables:
+    S3_BUCKET_NAME: "mender-binaries"
+    S3_BUCKET_PATH: "mender-monitor/yocto"
+  dependencies:
+    - init:workspace
+    - init:mender-monitor-package
+  before_script:
+    # Install dependencies
+    - apt update && apt install -yyq awscli git wget python3 python3-pip
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz stage-artifacts /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/stage-artifacts .
+  script:
+    - mender_monitor_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-monitor --in-integration-version $INTEGRATION_REV)
+    - echo "=== mender-monitor $mender_monitor_version ==="
+    - echo "Publishing $mender_monitor_version version to s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_monitor_version/"
+    - aws s3 cp stage-artifacts/monitor-client-*.tar.gz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_monitor_version/
+
+release_mender-monitor:manual:
+  when: manual
+  extends: .template_release_mender-monitor
+
+release_mender-monitor:automatic:
+  only:
+    variables:
+      - $PUBLISH_RELEASE_AUTOMATIC == "true"
+  extends: .template_release_mender-monitor
+
 # This job allows mender repo to publish the related Docker client images on
 # merges to master or release branches.
 # Do not confuse with release_docker_images which publishes all images

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -8,7 +8,7 @@
   services:
     - docker:19.03-dind
   dependencies:
-    - init_workspace
+    - init:workspace
     - build:servers
     - build:client:qemu
     - build:client:docker
@@ -59,7 +59,7 @@ release_docker_images:automatic:
   stage: release
   image: debian:buster
   dependencies:
-    - init_workspace
+    - init:workspace
     - test:acceptance:qemux86_64:uefi_grub
     - test:acceptance:vexpress_qemu
     - test:acceptance:qemux86_64:bios_grub
@@ -117,7 +117,7 @@ release_board_artifacts:automatic:
   stage: release
   image: debian:buster
   dependencies:
-    - init_workspace
+    - init:workspace
     - build:mender-cli
     - build:mender-artifact
   before_script:
@@ -191,7 +191,7 @@ release_docker_images:automatic:client-only:
   services:
     - docker:19.03-dind
   dependencies:
-    - init_workspace
+    - init:workspace
     - build:client:qemu
     - build:client:docker
   before_script:

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -440,7 +440,7 @@ test:backend-integration:open_source:
   tags:
     - mender-qa-slave-highcpu
   needs:
-    - init_workspace
+    - init:workspace
     - build:servers
     - build:mender-artifact
   before_script:
@@ -746,7 +746,7 @@ test:integration:source_client:open_source:
     variables:
       - ( $RUN_INTEGRATION_TESTS == "true" && $BUILD_CLIENT == "true" )
   needs:
-    - init_workspace
+    - init:workspace
     - build:servers
     - build:client:qemu
     - build:client:docker
@@ -769,7 +769,7 @@ test:integration:prebuilt_client:open_source:
     variables:
       - $BUILD_CLIENT == "true"
   needs:
-    - init_workspace
+    - init:workspace
     - build:servers
     - build:mender-artifact
     - build:mender-cli

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -123,11 +123,14 @@ FILESEXTRAPATHS_prepend_pn-mender-binary-delta := "$WORKSPACE/mender-binary-delt
 PREFERRED_VERSION_pn-mender-binary-delta = "$mender_binary_delta_version"
 EOF
 
+    local mender_monitor_version=$(tar -xf $WORKSPACE/stage-artifacts/mender-monitor-*.tar.gz ./mender-monitor/.version -O | egrep -o '[0-9]+\.[0-9]+\.[0-9b]+(-build[0-9]+)?')
+    if [ -z "$mender_monitor_version" ]; then
+        mender_monitor_version="master-git"
+    fi
     cat >> $BUILDDIR/conf/local.conf <<EOF
 LICENSE_FLAGS_WHITELIST += "commercial_mender-monitor"
-FILESEXTRAPATHS_prepend_pn-mender-monitor := "$WORKSPACE:"
-SRC_URI_pn-mender-monitor = "file://monitor-client/"
-PREFERRED_VERSION_pn-mender-monitor = "master-git"
+SRC_URI_pn-mender-monitor = "file:///$WORKSPACE/stage-artifacts/mender-monitor-*.tar.gz"
+PREFERRED_VERSION_pn-mender-monitor = "$mender_monitor_version"
 EOF
 
     if [ "$MENDER_CONFIGURE_MODULE_VERSION" != "latest" ]; then


### PR DESCRIPTION
    Namely:
    * Build package in new job from init stage. Done in a separate yml file
      so that it can be reused
    * Modify yocto-build-and-test.sh to use directly tar.gz as input for the
      recipe
    * Publish tarball to new S3 bucket mender-binaries for releases
