### PR TITLE
Restore mender-monitor from tarball

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -134,7 +134,6 @@ init:workspace:
     - checkout_repo MENDER_CONNECT https://github.com/mendersoftware/mender-connect go/src/github.com/mendersoftware/mender-connect $MENDER_CONNECT_REV
     - checkout_repo DEVICECONFIG https://github.com/mendersoftware/deviceconfig go/src/github.com/mendersoftware/deviceconfig $DEVICECONFIG_REV
     - checkout_repo DEVICEMONITOR git@github.com:mendersoftware/devicemonitor go/src/github.com/mendersoftware/devicemonitor $DEVICEMONITOR_REV
-    - checkout_repo MONITOR_CLIENT git@github.com:mendersoftware/monitor-client monitor-client $MONITOR_CLIENT_REV
     - checkout_repo REPORTING https://github.com/mendersoftware/reporting go/src/github.com/mendersoftware/reporting $REPORTING_REV
 
     # Print for debug purposes

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -5,9 +5,6 @@ set -e -x -E
 
 echo "WORKSPACE=$WORKSPACE"
 
-# Verify that version references are up to date.
-$WORKSPACE/integration/extra/release_tool.py --verify-integration-references
-
 build_servers_repositories() {
     # Use release tool to query for available docker names.
     for docker in $($WORKSPACE/integration/extra/release_tool.py --list docker ); do (

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -96,7 +96,6 @@ copy_build_conf() {
 }
 
 prepare_build_config() {
-    local i
     local machine
     machine=$1
     local board
@@ -126,16 +125,12 @@ PREFERRED_VERSION_pn-mender-binary-delta = "$mender_binary_delta_version"
 EOF
 
     local mender_monitor_version=$(tar -Oxf $WORKSPACE/stage-artifacts/mender-monitor-*.tar.gz ./mender-monitor/.version | egrep -o '[0-9]+\.[0-9]+\.[0-9b]+(-build[0-9]+)?')
-    for i in $WORKSPACE/stage-artifacts/mender-monitor-*.tar.gz; do
-        tar -C $WORKSPACE/stage-artifacts -xvzf $i
-    done
     if [ -z "$mender_monitor_version" ]; then
-        mender_monitor_version="master-git"
+        mender_monitor_version="master-git%"
     fi
     cat >> $BUILDDIR/conf/local.conf <<EOF
 LICENSE_FLAGS_WHITELIST += "commercial_mender-monitor"
-FILESEXTRAPATHS_prepend_pn-mender-monitor := "/$WORKSPACE/stage-artifacts/:"
-SRC_URI_pn-mender-monitor = "file://mender-monitor/"
+SRC_URI_pn-mender-monitor = "file:///$WORKSPACE/stage-artifacts/mender-monitor-*.tar.gz"
 PREFERRED_VERSION_pn-mender-monitor = "$mender_monitor_version"
 EOF
 

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -229,9 +229,6 @@ EOF
 }
 
 init_environment() {
-    # Verify that version references are up to date.
-    $WORKSPACE/integration/extra/release_tool.py --verify-integration-references
-
     # Verify mender-qa directory exists
     if [ ! -d mender-qa ]
     then


### PR DESCRIPTION
Main commit:

    Restore the tarball as input for the yocto build.
    
    The meta-mender recipes are meant to use the tarball as the input, not
    the uncompressed files. This is the way that users will built it, so we
    need to verify the same workflow.
    
    Partially reverts: ""Monitoring: decompress the tar archive and use it
    for build, repo name fix"
    
    This partially reverts commit 2c0c70a3efa67db111168de1c94d11a39970987a.
