### PR TITLE
QA-322: Rework child pipelines triggers

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ include:
   - local: '/gitlab-pipeline/stage/init-mender-monitor-package.yml'
   - local: '/gitlab-pipeline/stage/build.yml'
   - local: '/gitlab-pipeline/stage/test.yml'
-  - local: '/gitlab-pipeline/stage/publish.yml'
+  - local: '/gitlab-pipeline/stage/publish-tests.yml'
   - local: '/gitlab-pipeline/stage/trigger.yml'
   - local: '/gitlab-pipeline/stage/release.yml'
   - local: '/gitlab-pipeline/stage/post.yml'
@@ -118,7 +118,7 @@ stages:
   - init
   - build
   - test
-  - publish
+  - publish:tests
   - trigger
   - release
   - .post

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,6 +66,13 @@ variables:
   SPECIFIC_INTEGRATION_TEST: ""
   TESTS_IN_PARALLEL: "4"
 
+  # Child pipelines build and test
+  MENDER_CONVERT_REV: "master"
+  BUILD_MENDER_DIST_PACKAGES: "false"
+  BUILD_MENDER_CONVERT: "false"
+  TEST_MENDER_DIST_PACKAGES: "false"
+  TEST_MENDER_CONVERT: "false"
+
   # Publication
   PUBLISH_DOCKER_CLIENT_IMAGES: "false"
   PUBLISH_RELEASE_AUTOMATIC: "false"
@@ -106,7 +113,8 @@ include:
   - local: '/gitlab-pipeline/stage/build.yml'
   - local: '/gitlab-pipeline/stage/test.yml'
   - local: '/gitlab-pipeline/stage/publish-tests.yml'
-  - local: '/gitlab-pipeline/stage/trigger.yml'
+  - local: '/gitlab-pipeline/stage/trigger-packages.yml'
+  - local: '/gitlab-pipeline/stage/trigger-images.yml'
   - local: '/gitlab-pipeline/stage/release.yml'
   - local: '/gitlab-pipeline/stage/post.yml'
 
@@ -119,6 +127,7 @@ stages:
   - build
   - test
   - publish:tests
-  - trigger
   - release
+  - trigger:packages
+  - trigger:images
   - .post

--- a/gitlab-pipeline/stage/publish-tests.yml
+++ b/gitlab-pipeline/stage/publish-tests.yml
@@ -7,7 +7,7 @@
     variables:
       - $MENDER_REV =~ /pull\/.*\/head/
       - $NIGHTLY_BUILD == "true"
-  stage: publish
+  stage: publish:tests
   needs:
     - init:workspace
   image: golang:1.15-alpine3.12
@@ -43,7 +43,7 @@
       -parallel
       -coverprofile $(find ${CI_PROJECT_DIR}/acceptance-tests-coverage -name 'coverage*.out' | tr '\n' ',' | sed 's/,$//')
 
-publish:acceptance:qemux86_64:uefi_grub:
+publish:tests:acceptance:qemux86_64:uefi_grub:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -54,7 +54,7 @@ publish:acceptance:qemux86_64:uefi_grub:
   variables:
     JOB_BASE_NAME: qemux86_64_uefi_grub
 
-publish:acceptance:vexpress_qemu:
+publish:tests:acceptance:vexpress_qemu:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -65,7 +65,7 @@ publish:acceptance:vexpress_qemu:
   variables:
     JOB_BASE_NAME: vexpress_qemu
 
-publish:acceptance:qemux86_64:bios_grub:
+publish:tests:acceptance:qemux86_64:bios_grub:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -76,7 +76,7 @@ publish:acceptance:qemux86_64:bios_grub:
   variables:
     JOB_BASE_NAME: qemux86_64_bios_grub
 
-publish:acceptance:qemux86_64:bios_grub_gpt:
+publish:tests:acceptance:qemux86_64:bios_grub_gpt:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -87,7 +87,7 @@ publish:acceptance:qemux86_64:bios_grub_gpt:
   variables:
     JOB_BASE_NAME: qemux86_64_bios_grub_gpt
 
-publish:acceptance:vexpress_qemu:uboot_uefi_grub:
+publish:tests:acceptance:vexpress_qemu:uboot_uefi_grub:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -98,7 +98,7 @@ publish:acceptance:vexpress_qemu:uboot_uefi_grub:
   variables:
     JOB_BASE_NAME: vexpress_qemu_uboot_uefi_grub
 
-publish:acceptance:vexpress_qemu_flash:
+publish:tests:acceptance:vexpress_qemu_flash:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -109,7 +109,7 @@ publish:acceptance:vexpress_qemu_flash:
   variables:
     JOB_BASE_NAME: vexpress_qemu_flash
 
-publish:acceptance:beagleboneblack:
+publish:tests:acceptance:beagleboneblack:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -120,7 +120,7 @@ publish:acceptance:beagleboneblack:
   variables:
     JOB_BASE_NAME: beagleboneblack
 
-publish:acceptance:raspberrypi3:
+publish:tests:acceptance:raspberrypi3:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -131,7 +131,7 @@ publish:acceptance:raspberrypi3:
   variables:
     JOB_BASE_NAME: raspberrypi3
 
-publish:acceptance:raspberrypi4:
+publish:tests:acceptance:raspberrypi4:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
@@ -142,6 +142,7 @@ publish:acceptance:raspberrypi4:
   variables:
     JOB_BASE_NAME: raspberrypi4
 
+# TODO: move to other stage...
 publish:mender-dist-packages:
   stage: publish
   rules:

--- a/gitlab-pipeline/stage/publish-tests.yml
+++ b/gitlab-pipeline/stage/publish-tests.yml
@@ -141,28 +141,3 @@ publish:tests:acceptance:raspberrypi4:
     - test:acceptance:raspberrypi4
   variables:
     JOB_BASE_NAME: raspberrypi4
-
-# TODO: move to other stage...
-publish:mender-dist-packages:
-  stage: publish
-  rules:
-    # Disabled for the time being. See QA-322
-    - when: never
-    # - if: '$INTEGRATION_REV =~ /^[0-9]+\.[0-9]+\.[0-9]+(-build\d+)?$/'
-  variables:
-    # Unset DOCKER_ variables, the pipeline will execute on shared runners
-    DOCKER_HOST: "tcp://docker:2375"
-    DOCKER_CERT_PATH: ""
-    DOCKER_TLS_VERIFY: ""
-    DOCKER_TLS_CERTDIR: ""
-    # Mender release tagged versions:
-    MENDER_VERSION: $MENDER_REV
-    MENDER_CONNECT_VERSION: $MENDER_CONNECT_REV
-    # Obs! mender-configure-module is not part of the release (from release_tool eyes)
-    # so it cannot be passed downstream to mender-dist-packages.
-    # For this repo, we use the old flow of tag in repo -> trigger in mender-dist-packages
-    #MENDER_CONFIGURE_VERSION
-  trigger:
-    project: Northern.tech/Mender/mender-dist-packages
-    branch: master
-    strategy: depend

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -204,7 +204,7 @@ release_binary_tools:automatic:
     - mender_monitor_version=$($WORKSPACE/integration/extra/release_tool.py --version-of monitor-client --in-integration-version $INTEGRATION_REV)
     - echo "=== mender-monitor $mender_monitor_version ==="
     - echo "Publishing $mender_monitor_version version to s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_monitor_version/"
-    - aws s3 cp stage-artifacts/monitor-client-*.tar.gz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_monitor_version/
+    - aws s3 cp stage-artifacts/mender-monitor-*.tar.gz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_monitor_version/
 
 release_mender-monitor:manual:
   when: manual

--- a/gitlab-pipeline/stage/trigger-images.yml
+++ b/gitlab-pipeline/stage/trigger-images.yml
@@ -1,15 +1,15 @@
-.trigger_template:
-  stage: trigger
-  rules:
-    # Disabled for the time being. See QA-322
-    - when: never
-    # - if: '$INTEGRATION_REV =~ /^[0-9]+\.[0-9]+\.[0-9]+(-build\d+)?$/'
-    # # the following is to prevent an endless loop of qa pipelines caused by downstream pipelines
-    # - if: '$CI_PIPELINE_SOURCE == "pipeline"'
-    #   when: never
-
 trigger:mender-convert:
-  extends: .trigger_template
+  stage: trigger:images
+  needs:
+    - job: trigger:mender-dist-packages
+      artifacts: false
+    # Needs either manual or automatic release
+    - job: release_binary_tools:manual
+      artifacts: false
+    - job: release_binary_tools:automatic
+      artifacts: false
+  rules:
+    - if: $BUILD_MENDER_CONVERT == "true"
   variables:
     MENDER_ARTIFACT_VERSION: $MENDER_ARTIFACT_REV
     MENDER_CLIENT_VERSION: $MENDER_REV
@@ -18,7 +18,11 @@ trigger:mender-convert:
     # so it cannot be passed downstream to mender-convert.
     # It is not installed in our pre-converted images, so it doesn't really matter
     #MENDER_ADDON_CONFIGURE_VERSION
+
+    # Mode: "build and publish" or "build and test"
+    TEST_MENDER_CONVERT: $TEST_MENDER_CONVERT
+    PUBLISH_MENDER_CONVERT_AUTOMATIC: $PUBLISH_RELEASE_AUTOMATIC
   trigger:
     project: Northern.tech/Mender/mender-convert
-    branch: master
+    branch: $MENDER_CONVERT_REV
     strategy: depend

--- a/gitlab-pipeline/stage/trigger-images.yml
+++ b/gitlab-pipeline/stage/trigger-images.yml
@@ -1,15 +1,5 @@
-trigger:mender-convert:
+.template:trigger:mender-convert:
   stage: trigger:images
-  needs:
-    - job: trigger:mender-dist-packages
-      artifacts: false
-    # Needs either manual or automatic release
-    - job: release_binary_tools:manual
-      artifacts: false
-    - job: release_binary_tools:automatic
-      artifacts: false
-  rules:
-    - if: $BUILD_MENDER_CONVERT == "true"
   variables:
     MENDER_ARTIFACT_VERSION: $MENDER_ARTIFACT_REV
     MENDER_CLIENT_VERSION: $MENDER_REV
@@ -26,3 +16,26 @@ trigger:mender-convert:
     project: Northern.tech/Mender/mender-convert
     branch: $MENDER_CONVERT_REV
     strategy: depend
+
+
+# mender-convert downloads mender-artifact from upstream, so the trigger(s) either
+# need release_binary_tools:manual or release_binary_tools:automatic.
+trigger:mender-convert:manual:
+  needs:
+    - job: trigger:mender-dist-packages
+      artifacts: false
+    - job: release_binary_tools:manual
+      artifacts: false
+  rules:
+    - if: '$BUILD_MENDER_CONVERT == "true" && $PUBLISH_RELEASE_AUTOMATIC == "false"'
+  extends: .template:trigger:mender-convert
+
+trigger:mender-convert:automatic:
+  needs:
+    - job: trigger:mender-dist-packages
+      artifacts: false
+    - job: release_binary_tools:automatic
+      artifacts: false
+  rules:
+    - if: '$BUILD_MENDER_CONVERT == "true" && $PUBLISH_RELEASE_AUTOMATIC == "true"'
+  extends: .template:trigger:mender-convert

--- a/gitlab-pipeline/stage/trigger-packages.yml
+++ b/gitlab-pipeline/stage/trigger-packages.yml
@@ -24,5 +24,5 @@ trigger:mender-dist-packages:
     PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: $PUBLISH_RELEASE_AUTOMATIC
   trigger:
     project: Northern.tech/Mender/mender-dist-packages
-    branch: master
+    branch: QA-322-align-with-release-process
     strategy: depend

--- a/gitlab-pipeline/stage/trigger-packages.yml
+++ b/gitlab-pipeline/stage/trigger-packages.yml
@@ -1,0 +1,28 @@
+trigger:mender-dist-packages:
+  stage: trigger:packages
+  needs: []
+  rules:
+    - if: $BUILD_MENDER_DIST_PACKAGES == "true"
+  variables:
+    # Unset DOCKER_ variables, the pipeline will execute on shared runners
+    DOCKER_HOST: "tcp://docker:2375"
+    DOCKER_CERT_PATH: ""
+    DOCKER_TLS_VERIFY: ""
+    DOCKER_TLS_CERTDIR: ""
+
+    # Mender release tagged versions:
+    MENDER_VERSION: $MENDER_REV
+    MENDER_CONNECT_VERSION: $MENDER_CONNECT_REV
+    MENDER_MONITOR_VERSION: $MONITOR_CLIENT_REV
+    # Obs! mender-configure-module is not part of the release (from release_tool eyes)
+    # so it cannot be passed downstream to mender-dist-packages.
+    # For this repo, we use the old flow of tag in repo -> trigger in mender-dist-packages
+    #MENDER_CONFIGURE_VERSION
+
+    # Mode: "build and publish" or "build and test"
+    TEST_MENDER_DIST_PACKAGES: $TEST_MENDER_DIST_PACKAGES
+    PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: $PUBLISH_RELEASE_AUTOMATIC
+  trigger:
+    project: Northern.tech/Mender/mender-dist-packages
+    branch: master
+    strategy: depend


### PR DESCRIPTION
Have two explicit trigger stages: packages (mender-dist-packages) and
images (mender-convert). These are controlled by explicit variables
BUILD_* TEST_* and implicit variable PUBLISH_RELEASE_AUTOMATIC.
    
This should now align the full release process with the child pipelines,
and give the release coordinator the required flexibility to trigger
"build and publish" or "build and test" kind of pipelines.

Additionally, mender-convert version to use can be manually set by the
release coordinator with MENDER_CONVERT_REV - in the future we will have
it as part of the release_tool.