### PR TITLE
pipeline: more fixes for the release

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -209,7 +209,7 @@ build:mender-artifact:
   services:
     - docker:dind
   tags:
-    - docker
+    - mender-qa-slave-highcpu
   needs:
     - init:workspace
   before_script:

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -291,15 +291,13 @@ release_board_artifacts:raspberrypi4:automatic:
   extends: .template_release_board_artifacts
 
 .template_release_binary_tools:
+  # Jobs including this template must set either "dependencies" or "needs"
+  # for "init:workspace", "build:mender-cli" and "build:mender-artifact".
   only:
     variables:
       - ($BUILD_SERVERS == "true" && $BUILD_CLIENT == "true") || $RUN_INTEGRATION_TESTS == "true"
   stage: release
   image: debian:buster
-  dependencies:
-    - init:workspace
-    - build:mender-cli
-    - build:mender-artifact
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git wget python3 python3-pip
@@ -348,11 +346,10 @@ release_board_artifacts:raspberrypi4:automatic:
           --key mender-artifact/${mender_artifact_version}/${platform}/mender-artifact;
       done
 
-# Switch to needs for :manual to unlock mender-convert build in advance
+# Use "needs" for :manual to unlock mender-convert build in advance
 # or to trigger it despite mender-qa tests errors
 release_binary_tools:manual:
   when: manual
-  dependencies: []
   needs:
     - init:workspace
     - build:mender-cli
@@ -363,6 +360,10 @@ release_binary_tools:automatic:
   only:
     variables:
       - $PUBLISH_RELEASE_AUTOMATIC == "true"
+  dependencies:
+    - init:workspace
+    - build:mender-cli
+    - build:mender-artifact
   extends: .template_release_binary_tools
 
 .template_release_mender-monitor:

--- a/gitlab-pipeline/stage/trigger-packages.yml
+++ b/gitlab-pipeline/stage/trigger-packages.yml
@@ -24,5 +24,5 @@ trigger:mender-dist-packages:
     PUBLISH_MENDER_DIST_PACKAGES_AUTOMATIC: $PUBLISH_RELEASE_AUTOMATIC
   trigger:
     project: Northern.tech/Mender/mender-dist-packages
-    branch: QA-322-align-with-release-process
+    branch: master
     strategy: depend


### PR DESCRIPTION
pipeline: Fix release_binary_tools:manual job

    When using both "dependencies" and "needs", the former takes precedence,
    making the job not importing any of the required artifacts.

    Amends commit 5147749.

Revert "trigger-packages: switch to WIP branch QA-322-align-with-release-process"

    This reverts commit 45ee69de29d2ec3a2430e9f30495a24f1779ee8f.

pipeline: build:mender-artifact: switch to private runner

    For some reason this job hangs forever in some of the GitLab shared
    runners. Move it to our private ones.
