### PR TITLE
Restore monitor-client from shared workspace

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -134,6 +134,7 @@ init:workspace:
     - checkout_repo MENDER_CONNECT https://github.com/mendersoftware/mender-connect go/src/github.com/mendersoftware/mender-connect $MENDER_CONNECT_REV
     - checkout_repo DEVICECONFIG https://github.com/mendersoftware/deviceconfig go/src/github.com/mendersoftware/deviceconfig $DEVICECONFIG_REV
     - checkout_repo DEVICEMONITOR git@github.com:mendersoftware/devicemonitor go/src/github.com/mendersoftware/devicemonitor $DEVICEMONITOR_REV
+    - checkout_repo MONITOR_CLIENT git@github.com:mendersoftware/monitor-client monitor-client $MONITOR_CLIENT_REV
     - checkout_repo REPORTING https://github.com/mendersoftware/reporting go/src/github.com/mendersoftware/reporting $REPORTING_REV
 
     # Print for debug purposes


### PR DESCRIPTION
Removed at 06af5df when removing `--verify-integration-references` check
of the release_tool, but all repos in the workspace are also required
for `--select-test-suite` used in integration tests jobs.