### PR TITLE
init:workspace: Base the checkout repos list in release_tool list

### DIFF
--- a/Documentation/adding-new-repository.md
+++ b/Documentation/adding-new-repository.md
@@ -140,10 +140,7 @@ Set a weekly schedule to build master pipeline for every Tuesday evening, at 9 P
 
 Modify source code:
 
-* Add repository to `defaultWatchRepositories`
-* If closed source repo, add it to `enterpriseRepositories`
 * If client repository build with yocto, add it to `qemuBuildRepositories`
-* If backend repository with enterprise fork, add it to list in `syncIfOSHasEnterpriseRepo`
 
 ref https://github.com/mendersoftware/integration-test-runner/blob/master/main.go
 

--- a/Documentation/adding-new-repository.md
+++ b/Documentation/adding-new-repository.md
@@ -130,8 +130,6 @@ Set a weekly schedule to build master pipeline for every Tuesday evening, at 9 P
 1. Modify Mender QA Pipeline:
   * ref https://github.com/mendersoftware/mender-qa/blob/master/.gitlab-ci.yml
   * Add new repo into `variables`
-  * Add new call to `checkout_repo` in `init:workspace`.
-    * For private repositories, use ssh Git url
 2. Modify `servers-build.sh`
   * ref https://github.com/mendersoftware/mender-qa/blob/master/scripts/servers-build.sh
   * Add the new Docker images, if applicable, to `Build server repositories.`

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -17,6 +17,10 @@ init:workspace:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - apk --update add git openssh bash python3 curl py3-pip jq
 
+    # release_tool.py dependencies
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
+
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
@@ -32,15 +36,16 @@ init:workspace:
     # old integration release branches which don't have all current repos in component-maps.yml
     - |
       function checkout_repo() {
-        if [ $# -lt 3 ]; then
-          echo "Usage: checkout_repo repo_id clone_url clone_path [clone_rev]"
+        if [ $# -lt 2 ]; then
+          echo "Usage: checkout_repo clone_url clone_path [clone_rev]"
           return 1
         fi
 
-        repo_id=$1
-        clone_url=$2
-        clone_path=$3
-        clone_rev=${4:-master}
+        clone_url=$1
+        clone_path=$2
+        clone_rev=${3:-master}
+
+        repo_id=$(basename $clone_url .git | tr [a-z-] [A-Z_])
 
         git clone $clone_url $clone_path || return 1
 
@@ -57,6 +62,12 @@ init:workspace:
           echo "export ${repo_id}_REV=$clone_rev" >> ${CI_PROJECT_DIR}/build_revisions.env
           echo "export ${repo_id}_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env
         ) || return 1
+      }
+
+    # Get revision for a repository (i.e mender-something to $MENDER_SOMETHING_REV)
+    - |
+      function repo_to_rev() {
+          echo "$(eval echo \$$(echo $1 | tr [a-z-] [A-Z_])_REV)"
       }
 
     # Clean WORKSPACE and clone poky in the root
@@ -87,7 +98,7 @@ init:workspace:
     -   echo "export MENDER_QA_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env
     - )
 
-    - checkout_repo INTEGRATION https://github.com/mendersoftware/integration integration $INTEGRATION_REV
+    - checkout_repo https://github.com/mendersoftware/integration integration $INTEGRATION_REV
 
     # Fetch all branches for integration. This is needed during the publish
     # stage when we query versions using the release_tool. Other repositories
@@ -105,40 +116,19 @@ init:workspace:
     -   git fetch --tags origin
     - )
 
+    # Add Mender repositories.
+    - for repo in $(integration/extra/release_tool.py --list); do
+    -   checkout_repo \
+          git@github.com:mendersoftware/$repo \
+          go/src/github.com/mendersoftware/$repo \
+          $(repo_to_rev $repo)
+    - done
+
     # Add other repositories.
-    - checkout_repo META_MENDER https://github.com/mendersoftware/meta-mender meta-mender $META_MENDER_REV
-    - checkout_repo MENDER https://github.com/mendersoftware/mender go/src/github.com/mendersoftware/mender $MENDER_REV
-    - checkout_repo AZURE_IOT_MANAGER https://github.com/mendersoftware/azure-iot-manager go/src/github.com/mendersoftware/azure-iot-manager $AZURE_IOT_MANAGER_REV
-    - checkout_repo MENDER_AUTH_AZURE_IOT https://github.com/mendersoftware/mender-auth-azure-iot go/src/github.com/mendersoftware/mender-auth-azure-iot $MENDER_AUTH_AZURE_IOT_REV
-    - checkout_repo DEPLOYMENTS https://github.com/mendersoftware/deployments go/src/github.com/mendersoftware/deployments $DEPLOYMENTS_REV
-    - checkout_repo DEPLOYMENTS_ENTERPRISE git@github.com:mendersoftware/deployments-enterprise go/src/github.com/mendersoftware/deployments-enterprise $DEPLOYMENTS_ENTERPRISE_REV
-    - checkout_repo DEVICEAUTH https://github.com/mendersoftware/deviceauth go/src/github.com/mendersoftware/deviceauth $DEVICEAUTH_REV
-    - checkout_repo DEVICEAUTH_ENTERPRISE git@github.com:mendersoftware/deviceauth-enterprise go/src/github.com/mendersoftware/deviceauth-enterprise $DEVICEAUTH_ENTERPRISE_REV
-    - checkout_repo GUI https://github.com/mendersoftware/gui gui $GUI_REV
-    - checkout_repo INVENTORY https://github.com/mendersoftware/inventory go/src/github.com/mendersoftware/inventory $INVENTORY_REV
-    - checkout_repo INVENTORY_ENTERPRISE git@github.com:mendersoftware/inventory-enterprise.git go/src/github.com/mendersoftware/inventory-enterprise $INVENTORY_ENTERPRISE_REV
-    - checkout_repo USERADM https://github.com/mendersoftware/useradm go/src/github.com/mendersoftware/useradm $USERADM_REV
-    - checkout_repo USERADM_ENTERPRISE git@github.com:mendersoftware/useradm-enterprise go/src/github.com/mendersoftware/useradm-enterprise $USERADM_ENTERPRISE_REV
-    - checkout_repo MENDER_API_GATEWAY_DOCKER https://github.com/mendersoftware/mender-api-gateway-docker mender-api-gateway-docker $MENDER_API_GATEWAY_DOCKER_REV
-    - checkout_repo MENDER_STRESS_TEST_CLIENT https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client $MENDER_STRESS_TEST_CLIENT_REV
-    - checkout_repo MENDER_ARTIFACT https://github.com/mendersoftware/mender-artifact go/src/github.com/mendersoftware/mender-artifact $MENDER_ARTIFACT_REV
-    - checkout_repo TENANTADM git@github.com:mendersoftware/tenantadm go/src/github.com/mendersoftware/tenantadm $TENANTADM_REV
-    - checkout_repo WORKFLOWS git@github.com:mendersoftware/workflows go/src/github.com/mendersoftware/workflows $WORKFLOWS_REV
-    - checkout_repo WORKFLOWS_ENTERPRISE git@github.com:mendersoftware/workflows-enterprise go/src/github.com/mendersoftware/workflows-enterprise $WORKFLOWS_ENTERPRISE_REV
-    - checkout_repo CREATE_ARTIFACT_WORKER git@github.com:mendersoftware/create-artifact-worker go/src/github.com/mendersoftware/create-artifact-worker $CREATE_ARTIFACT_WORKER_REV
-    - checkout_repo META_OPENEMBEDDED git://git.openembedded.org/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV
-    - checkout_repo META_RASPBERRYPI https://github.com/agherzan/meta-raspberrypi.git meta-raspberrypi $META_RASPBERRYPI_REV
-    - checkout_repo MENDER_CONDUCTOR https://github.com/mendersoftware/mender-conductor.git go/src/github.com/mendersoftware/mender-conductor $MENDER_CONDUCTOR_REV
-    - checkout_repo MENDER_CONDUCTOR_ENTERPRISE git@github.com:mendersoftware/mender-conductor-enterprise.git go/src/github.com/mendersoftware/mender-conductor-enterprise $MENDER_CONDUCTOR_ENTERPRISE_REV
-    - checkout_repo MENDER_CLI https://github.com/mendersoftware/mender-cli.git go/src/github.com/mendersoftware/mender-cli $MENDER_CLI_REV
-    - checkout_repo AUDITLOGS git@github.com:mendersoftware/auditlogs go/src/github.com/mendersoftware/auditlogs $AUDITLOGS_REV
-    - checkout_repo MTLS_AMBASSADOR git@github.com:mendersoftware/mtls-ambassador go/src/github.com/mendersoftware/mtls-ambassador $MTLS_AMBASSADOR_REV
-    - checkout_repo DEVICECONNECT https://github.com/mendersoftware/deviceconnect go/src/github.com/mendersoftware/deviceconnect $DEVICECONNECT_REV
-    - checkout_repo MENDER_CONNECT https://github.com/mendersoftware/mender-connect go/src/github.com/mendersoftware/mender-connect $MENDER_CONNECT_REV
-    - checkout_repo DEVICECONFIG https://github.com/mendersoftware/deviceconfig go/src/github.com/mendersoftware/deviceconfig $DEVICECONFIG_REV
-    - checkout_repo DEVICEMONITOR git@github.com:mendersoftware/devicemonitor go/src/github.com/mendersoftware/devicemonitor $DEVICEMONITOR_REV
-    - checkout_repo MONITOR_CLIENT git@github.com:mendersoftware/monitor-client monitor-client $MONITOR_CLIENT_REV
-    - checkout_repo REPORTING https://github.com/mendersoftware/reporting go/src/github.com/mendersoftware/reporting $REPORTING_REV
+    - checkout_repo https://github.com/mendersoftware/meta-mender meta-mender $META_MENDER_REV
+    - checkout_repo https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client $MENDER_STRESS_TEST_CLIENT_REV
+    - checkout_repo git://git.openembedded.org/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV
+    - checkout_repo https://github.com/agherzan/meta-raspberrypi.git meta-raspberrypi $META_RASPBERRYPI_REV
 
     # Print for debug purposes
     - cat ${CI_PROJECT_DIR}/build_revisions.env

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -12,21 +12,20 @@ build_servers_repositories() {
         git=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker git)
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $docker docker_url)
 
+        cd go/src/github.com/mendersoftware/$git
+
         case "$docker" in
             azure-iot-manager|deployments|deployments-enterprise|deviceauth|deviceauth-enterprise|inventory|inventory-enterprise|tenantadm|useradm|useradm-enterprise|workflows|workflows-enterprise|create-artifact-worker|auditlogs|mtls-ambassador|deviceconnect|deviceconfig|devicemonitor|reporting)
-                cd go/src/github.com/mendersoftware/$git
                 docker build -t $docker_url:pr .
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             workflows-worker|workflows-enterprise-worker)
-                cd go/src/github.com/mendersoftware/$git
                 docker build -t $docker_url:pr -f Dockerfile.worker .
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             gui)
-                cd gui
                 # GIT_REF + GIT_COMMIT for 2.3 or older, GIT_COMMIT_TAG for newer
                 docker build \
                     -t $docker_url:pr \
@@ -53,25 +52,21 @@ build_servers_repositories() {
                 ;;
 
             api-gateway)
-                cd $git
                 docker build -t $docker_url:pr .
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             mender-conductor|mender-conductor-enterprise)
-                cd go/src/github.com/mendersoftware/$git
                 docker build --build-arg REVISION=pr -t $docker_url:pr ./server
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             email-sender)
-                cd go/src/github.com/mendersoftware/$git
                 docker build -t $docker_url:pr ./workers/send_email
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;
 
             org-welcome-email-preparer)
-                cd go/src/github.com/mendersoftware/$git
                 docker build --build-arg REVISION=pr -t $docker_url:pr ./workers/prepare_org_welcome_email
                 $WORKSPACE/integration/extra/release_tool.py --set-version-of $docker --version pr
                 ;;


### PR DESCRIPTION
* init:workspace: Base the checkout repos list in release_tool list
So that we remove one more point of duplication.
All repos get now cloned to the go/src/... path, which one might argue
that is unnecessary for gui, integration or other repos, but I argue
back that is harmless and makes the code simple :)
(Actually, integration gets now checked out twice...)


* adding-new-repository.md: Update integration-test-runner section
Removing some deprecated parts and following up clean-up from
https://github.com/mendersoftware/integration-test-runner/pull/139
    
