### PR TITLE
yocto related jobs: Refactor script to error on missing artifacts

### DIFF
--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -26,7 +26,6 @@
     - modprobe -r kvm_intel && modprobe kvm_intel nested=Y
     # Enable NFS cache for yocto
     - mount.nfs4 ${SSTATE_CACHE_INTRNL_ADDR}:/sstate-cache /mnt/sstate-cache
-  script:
     # Traps only work if executed in a sub shell.
     - "("
     - mv workspace.tar.gz stage-artifacts /tmp

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -11,16 +11,18 @@ build:client:qemu:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
     ONLY_BUILD: "true"
     BUILD_DOCKER_IMAGES: "true"
-  after_script:
-    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
-
+  script:
+    - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
     - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
     -   docker save registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:pr -o stage-artifacts/mender-monitor-qemu-commercial.tar
     - fi
+  after_script:
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -22,14 +22,18 @@ test:acceptance:qemux86_64:uefi_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -41,8 +45,6 @@ test:acceptance:qemux86_64:uefi_grub:
         $build_name
         results_accep_qemux86_64_uefi_grub.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -72,14 +74,18 @@ test:acceptance:vexpress_qemu:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/vexpress-qemu/vexpress-qemu_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_VEXPRESS_QEMU" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -91,8 +97,6 @@ test:acceptance:vexpress_qemu:
         $build_name
         results_accep_vexpress_qemu.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/vexpress-qemu/vexpress-qemu_release_1_*.mender stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -122,14 +126,18 @@ test:acceptance:qemux86_64:bios_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-bios-grub/qemux86-64-bios-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -141,8 +149,6 @@ test:acceptance:qemux86_64:bios_grub:
         $build_name
         results_accep_qemux86_64_bios_grub.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/qemux86-64-bios-grub/qemux86-64-bios-grub_release_1_*.mender stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -172,14 +178,18 @@ test:acceptance:qemux86_64:bios_grub_gpt:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-bios-grub-gpt/qemux86-64-bios-grub-gpt_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB_GPT" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_bios_grub_gpt.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -191,8 +201,6 @@ test:acceptance:qemux86_64:bios_grub_gpt:
         $build_name
         results_accep_qemux86_64_bios_grub_gpt.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/qemux86-64-bios-grub-gpt/qemux86-64-bios-grub-gpt_release_1_*.mender stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -222,14 +230,18 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/vexpress-qemu-uboot-uefi-grub/vexpress-qemu-uboot-uefi-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_uboot_uefi_grub.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -241,8 +253,6 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
         $build_name
         results_accep_vexpress_qemu_uboot_uefi_grub.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/vexpress-qemu-uboot-uefi-grub/vexpress-qemu-uboot-uefi-grub_release_1_*.mender stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -275,14 +285,18 @@ test:acceptance:vexpress_qemu_flash:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_flash
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/vexpress-qemu-flash/core-image-minimal-vexpress-qemu-flash.ubifs stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_VEXPRESS_QEMU_FLASH" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html;
-      fi
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_vexpress_qemu_flash.html
+    - fi
 
     - if [ "$NIGHTLY_BUILD" = "true" ]; then
     -   build_name=nightly-$(date +%Y-%m-%d)
@@ -294,8 +308,6 @@ test:acceptance:vexpress_qemu_flash:
         $build_name
         results_accep_vexpress_qemu_flash.xml || true
 
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/vexpress-qemu-flash/core-image-minimal-vexpress-qemu-flash.ubifs stage-artifacts/
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -325,17 +337,20 @@ test:acceptance:beagleboneblack:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_beagleboneblack
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/beagleboneblack/beagleboneblack_release_1_*.mender stage-artifacts/
+    - cp $WORKSPACE/beagleboneblack/mender-beagleboneblack_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_BEAGLEBONEBLACK" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html;
-      fi
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/beagleboneblack/beagleboneblack_release_1_*.mender stage-artifacts/
-    - cp $WORKSPACE/beagleboneblack/mender-beagleboneblack_*.sdimg.gz stage-artifacts/
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_beagleboneblack.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_beagleboneblack.html
+    - fi
+
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -365,17 +380,20 @@ test:acceptance:raspberrypi3:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_raspberrypi3
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/raspberrypi3/raspberrypi3_release_1_*.mender stage-artifacts/
+    - cp $WORKSPACE/raspberrypi3/mender-raspberrypi3_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_RASPBERRYPI3" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html;
-      fi
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/raspberrypi3/raspberrypi3_release_1_*.mender stage-artifacts/
-    - cp $WORKSPACE/raspberrypi3/mender-raspberrypi3_*.sdimg.gz stage-artifacts/
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_raspberrypi3.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_raspberrypi3.html
+    - fi
+
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
@@ -405,17 +423,20 @@ test:acceptance:raspberrypi4:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_raspberrypi4
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/raspberrypi4/raspberrypi4_release_1_*.mender stage-artifacts/
+    - cp $WORKSPACE/raspberrypi4/mender-raspberrypi4_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
 
     - if [ "$TEST_RASPBERRYPI4" = "true" ]; then
-        cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_raspberrypi4.xml;
-        cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_raspberrypi4.html;
-      fi
-    - mkdir -p stage-artifacts
-    - cp $WORKSPACE/raspberrypi4/raspberrypi4_release_1_*.mender stage-artifacts/
-    - cp $WORKSPACE/raspberrypi4/mender-raspberrypi4_*.sdimg.gz stage-artifacts/
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_raspberrypi4.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_raspberrypi4.html
+    - fi
+
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 


### PR DESCRIPTION
Move all code of the template to `before_script` so that the jobs can
have in their script the collection of the stage artifacts, so that if
something errors there the build job errors (`after_script` is allowed
to fail).

The main motivation is to catch these issue where the last qemu image is
not collected in `build:client:qemu` but the problem is only seen once
we are running integration tests...

Once in the area, the syntax for an if snippet has been updated.