### PR TITLE
init:workspace: fix typo in shell snippet

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -118,9 +118,9 @@ init:workspace:
 
     # Add Mender repositories.
     - for repo in $(integration/extra/release_tool.py --list); do
-    -   checkout_repo \
-          git@github.com:mendersoftware/$repo \
-          go/src/github.com/mendersoftware/$repo \
+    -   checkout_repo
+          git@github.com:mendersoftware/$repo
+          go/src/github.com/mendersoftware/$repo
           $(repo_to_rev $repo)
     - done
 


### PR DESCRIPTION
Once concatenated by GitLab becomes:
`checkout_repo \ git... \ go/... \ $(repo_to_rev $repo)`, which
introduces a white space in the last argument.

Amends commit 0fc09a1.