### PR TITLE
MEN-5300: Add mender-gateway to the integration pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,6 +37,7 @@ variables:
   DEVICEMONITOR_REV: "master"
   MONITOR_CLIENT_REV: "master"
   REPORTING_REV: "master"
+  MENDER_GATEWAY_REV: "master"
 
   # Versions of independent components
   MENDER_BINARY_DELTA_VERSION: "latest"

--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -3,7 +3,8 @@
   image: mendersoftware/mender-test-containers:mender-client-acceptance-testing
   needs:
     - init:workspace
-    - build:mender-monitor-package
+    - build:mender-monitor:package
+    - build:mender-gateway:package
   tags:
     - mender-qa-slave-highcpu
   before_script:

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -1,4 +1,9 @@
 
+include:
+  - project: 'Northern.tech/Mender/mender-gateway'
+    file: '.gitlab-ci-build-package.yml'
+    ref: $MENDER_GATEWAY_REV
+
 build:client:docker:
   stage: build
   only:
@@ -96,7 +101,7 @@ build:servers:
 
     - mkdir -p stage-artifacts
     - for image in $(${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker); do
-    -   if ! echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -   if ! echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
     -     docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $image docker_url)
     -     docker save $docker_url:pr -o stage-artifacts/${image}.tar
     -   fi
@@ -216,7 +221,7 @@ build:mender-artifact:
     paths:
       - stage-artifacts/
 
-build:mender-monitor-package:
+build:mender-monitor:package:
   stage: build
   image: alpine:3.12
   needs: []
@@ -245,3 +250,19 @@ build:mender-monitor-package:
   artifacts:
     paths:
       - stage-artifacts
+
+build:mender-gateway:package:
+  stage: build
+  needs:
+    - init:workspace
+  before_script:
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz build_revisions.env /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/build_revisions.env .
+    # Move into component path
+    - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-gateway

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -374,7 +374,7 @@ release_binary_tools:automatic:
     S3_BUCKET_PATH: "mender-monitor/yocto"
   dependencies:
     - init:workspace
-    - build:mender-monitor-package
+    - build:mender-monitor:package
   before_script:
     # Install dependencies
     - apt update && apt install -yyq awscli git wget python3 python3-pip
@@ -403,6 +403,44 @@ release_mender-monitor:automatic:
     variables:
       - $PUBLISH_RELEASE_AUTOMATIC == "true"
   extends: .template_release_mender-monitor
+
+.template_release_mender-gateway:
+  stage: release
+  image: debian:buster
+  variables:
+    S3_BUCKET_NAME: "mender-binaries"
+    S3_BUCKET_PATH: "mender-gateway/yocto"
+  dependencies:
+    - init:workspace
+    - build:mender-gateway:package
+  before_script:
+    # Install dependencies
+    - apt update && apt install -yyq awscli git wget python3 python3-pip
+    - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
+    - pip3 install -r requirements.txt
+    # Restore workspace from init stage
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - mv workspace.tar.gz stage-artifacts /tmp
+    - rm -rf ${WORKSPACE}
+    - mkdir -p ${WORKSPACE}
+    - cd ${WORKSPACE}
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/stage-artifacts .
+  script:
+    - mender_gateway_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-gateway --in-integration-version $INTEGRATION_REV)
+    - echo "=== mender-gateway $mender_gateway_version ==="
+    - echo "Publishing $mender_gateway_version version to s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_gateway_version/"
+    - aws s3 cp stage-artifacts/mender-gateway-*.tar.xz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_gateway_version/
+
+release_mender-gateway:manual:
+  when: manual
+  extends: .template_release_mender-gateway
+
+release_mender-gateway:automatic:
+  only:
+    variables:
+      - $PUBLISH_RELEASE_AUTOMATIC == "true"
+  extends: .template_release_mender-gateway
 
 # This job allows mender repo to publish the related Docker client images on
 # merges to master or release branches.
@@ -444,7 +482,7 @@ release_docker_images:automatic:client-only:
     -   VERSION_TYPE_PARAMS="--version-type docker"
     - fi
     # Load, tag and push mender-client-* images
-    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-monitor'); do
+    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-monitor|mender-gateway'); do
         version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
         docker load -i stage-artifacts/${image}.tar;

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -35,7 +35,7 @@ test:backend-integration:open_source:
 
     # Load all docker images except client
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if ! echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -   if ! echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
     -     docker load -i stage-artifacts/${image}.tar
     -   fi
     - done
@@ -194,7 +194,7 @@ test:backend-integration:enterprise:
 
     # Load all docker images, and the client images depending on $BUILD_CLIENT
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -   if echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
     -       docker load -i stage-artifacts/${image}.tar
     -     else
@@ -209,7 +209,7 @@ test:backend-integration:enterprise:
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if echo $image | egrep -q 'mender-client|mender-monitor'; then
+    -   if echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
     -       integration/extra/release_tool.py --set-version-of $image --version pr
     -     else

--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -31,6 +31,9 @@ build:client:qemu:
     - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
     -   docker save registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:pr -o stage-artifacts/mender-monitor-qemu-commercial.tar
     - fi
+    - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
+    -   docker save registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:pr -o stage-artifacts/mender-gateway-qemu-commercial.tar
+    - fi
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -48,7 +48,7 @@ build_servers_repositories() {
                     :
                     ;;
 
-                mender-monitor-qemu-commercial)
+                mender-monitor-qemu-commercial|mender-gateway-qemu-commercial)
                     # Built in yocto-build-and-test.sh::build_and_test_client
                     :
                     ;;

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -380,21 +380,17 @@ build_and_test_client() {
                 --version pr
         fi
 
-        # Check if there is a R/O rootfs recipe available.
-        if [[ $image_name == core-image-full-cmdline ]] \
-               && [[ -f $WORKSPACE/meta-mender/meta-mender-demo/recipes-extended/images/mender-image-full-cmdline-rofs.bb ]]; then
+        # R/O image
+        if [[ $image_name == core-image-full-cmdline ]]; then
             bitbake mender-image-full-cmdline-rofs
             if ${BUILD_DOCKER_IMAGES:-false}; then
                 $WORKSPACE/meta-mender/meta-mender-qemu/docker/build-docker \
                     -i mender-image-full-cmdline-rofs \
                     $machine_name \
                     -t mendersoftware/mender-client-qemu-rofs:pr
-                # It's ok if the next step fails, it just means we are
-                # testing a version of integration that neither has a rofs
-                # image, nor any tests for it.
                 $WORKSPACE/integration/extra/release_tool.py \
                     --set-version-of mender-client-qemu-rofs \
-                    --version pr || true
+                    --version pr
             fi
         fi
 


### PR DESCRIPTION
Changes in all related parts to build the binaries (by including the
remote CI job), build the image using these binaries, and release the
image and the tarball with the binaries.



Bonus:
* yocto-build-and-test.sh: Build R/O image unconditionally
    Just a clean up - all our supported Mender versions have the image, plus
    the CI script does "docker save" on it unconditionally.
