### PR TITLE
Bringing back ./gitlab-pipeline/stage/init-mender-monitor-package.yml

### DIFF
--- a/gitlab-pipeline/stage/init-mender-monitor-package.yml
+++ b/gitlab-pipeline/stage/init-mender-monitor-package.yml
@@ -1,0 +1,28 @@
+init:mender-monitor-package:
+  stage: init
+  image: alpine:3.12
+  before_script:
+    - apk add --no-cache git openssh
+    # Prepare SSH keys
+    - eval $(ssh-agent -s)
+    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add - > /dev/null
+    - mkdir -p ~/.ssh
+    - chmod 700 ~/.ssh
+    - ssh-keyscan github.com >> ~/.ssh/known_hosts
+    # Clone monitor-client
+    - git clone git@github.com:mendersoftware/monitor-client monitor-client
+    - cd monitor-client
+    - ( git fetch -u -f origin $MONITOR_CLIENT_REV:pr &&
+          git checkout pr ||
+          git checkout -f -b pr $MONITOR_CLIENT_REV
+      ) || return 1
+  script:
+    - apk add --no-cache make git
+    - git fetch --tags origin
+    - make package
+    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    - mv mender-monitor-*.tar.gz ${CI_PROJECT_DIR}/stage-artifacts
+    - ls -lh ${CI_PROJECT_DIR}/stage-artifacts/
+  artifacts:
+    paths:
+      - stage-artifacts


### PR DESCRIPTION
removed in: 0689a9605b952a64e12a8b63e0f0462934eff49b
failures:
{..."level":"error",
... {message: {base: [... file `gitlab-pipeline/stage/init-mender-monitor-package.yml` does not exist!]}}",...}

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>