### PR TITLE
Set "master" for default MENDER_GATEWAY_REV on include

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -2,7 +2,7 @@
 include:
   - project: 'Northern.tech/Mender/mender-gateway'
     file: '.gitlab-ci-build-package.yml'
-    ref: $MENDER_GATEWAY_REV
+    ref: ${MENDER_GATEWAY_REV:-master}
 
 build:client:docker:
   stage: build


### PR DESCRIPTION
It seems like otherwise gets resolved to "" on include time which makes
the pipeline error and not start.