### PR TITLE
Hardcode include ref to "master" for build:mender-gateway:package

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -2,7 +2,7 @@
 include:
   - project: 'Northern.tech/Mender/mender-gateway'
     file: '.gitlab-ci-build-package.yml'
-    ref: $MENDER_GATEWAY_REV
+    ref: master
 
 build:client:docker:
   stage: build


### PR DESCRIPTION
It seems like otherwise gets resolved to "" on include time which makes
the pipeline error and not start.

I'll think about a way to version this include as a follow-up.