### PR TITLE
Pipeline handling for integration versions with no mender-gateway

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -256,6 +256,9 @@ build:mender-gateway:package:
   needs:
     - init:workspace
   before_script:
+    # Early exit when building an integration version without mender-gateway
+    - tar -tf workspace.tar.gz
+        ./go/src/github.com/mendersoftware/mender-gateway  >/dev/null 2>/dev/null || exit 0
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env /tmp


### PR DESCRIPTION
Early exit on build:mender-gateway:package and test guard in yocto build
script to handle building and testing integration versions without this
component.

Slightly modified also the mender-monitor handling for coherence (it was
working on older integration versions just because it had a fallback for
empty string).