### PR TITLE
MEN-5475: mender-gateway demo: include and publish examples

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,16 +38,11 @@ variables:
   DEVICEMONITOR_REV: "master"
   MONITOR_CLIENT_REV: "master"
   REPORTING_REV: "master"
+  MENDER_GATEWAY_REV: "master"
 
   # Versions of independent components
   MENDER_BINARY_DELTA_VERSION: "latest"
   MENDER_CONFIGURE_MODULE_VERSION: "latest"
-
-  # The revision variables for the following components need to be defined also
-  # in the project's CI/CD settings because they are used in include statements
-  # See comment here: https://gitlab.com/gitlab-org/gitlab/-/issues/219065#note_619008094
-  # Defined here: https://gitlab.com/Northern.tech/Mender/mender-qa/-/settings/ci_cd
-  MENDER_GATEWAY_REV: "master"
 
   # Build stage
   BUILD_CLIENT: "true"

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -2,7 +2,7 @@
 include:
   - project: 'Northern.tech/Mender/mender-gateway'
     file: '.gitlab-ci-build-package.yml'
-    ref: $MENDER_GATEWAY_REV
+    ref: 'master'
 
 build:client:docker:
   stage: build

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -409,7 +409,8 @@ release_mender-monitor:automatic:
   image: debian:buster
   variables:
     S3_BUCKET_NAME: "mender-binaries"
-    S3_BUCKET_PATH: "mender-gateway/yocto"
+    S3_BUCKET_PATH_YOCTO: "mender-gateway/yocto"
+    S3_BUCKET_PATH_EXAMPLES: "mender-gateway/examples"
   dependencies:
     - init:workspace
     - build:mender-gateway:package
@@ -429,8 +430,9 @@ release_mender-monitor:automatic:
   script:
     - mender_gateway_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-gateway --in-integration-version $INTEGRATION_REV)
     - echo "=== mender-gateway $mender_gateway_version ==="
-    - echo "Publishing $mender_gateway_version version to s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_gateway_version/"
-    - aws s3 cp stage-artifacts/mender-gateway-*.tar.xz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH/$mender_gateway_version/
+    - echo "Publishing $mender_gateway_version version to s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_YOCTO/$mender_gateway_version/"
+    - aws s3 cp stage-artifacts/mender-gateway-*.tar.xz s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_YOCTO/$mender_gateway_version/
+    - aws s3 cp stage-artifacts/mender-gateway-examples-*.tar s3://$S3_BUCKET_NAME/$S3_BUCKET_PATH_EXAMPLES/$mender_gateway_version/
 
 release_mender-gateway:manual:
   when: manual

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -145,9 +145,11 @@ EOF
         if [ -z "$mender_gateway_version" ]; then
             mender_gateway_version="master-git%"
         fi
+        local mender_gateway_examples_filename=$(find $WORKSPACE/stage-artifacts/ -maxdepth 1  -name "mender-gateway-examples-*.tar" | head -n1 | xargs basename)
         cat >> $BUILDDIR/conf/local.conf <<EOF
 LICENSE_FLAGS_WHITELIST += "commercial_mender-gateway"
 SRC_URI_pn-mender-gateway = "file:///$WORKSPACE/stage-artifacts/$mender_gateway_filename"
+SRC_URI_pn-mender-gateway_append = " file:///$WORKSPACE/stage-artifacts/$mender_gateway_examples_filename"
 PREFERRED_VERSION_pn-mender-gateway = "$mender_gateway_version"
 EOF
     fi


### PR DESCRIPTION
    build.yml: Hardcode `ref: master` when including .gitlab-ci-build-package.yml
    
    This was introduced to be able to specifiy the version to include, but
    this turned out to be a problem for our tooling, as it will break when
    trying to include a "pull/XXX/head" kind of revision on PR builds.
    
    Remove it and rely on master. We expect this build job to be relatively
    stable so using master should be fine - for special cases we can always
    hardcode here a different revision.

and

    MEN-5475: mender-gateway demo: include and publish examples
    
    When building with meta-mender-demo layer on (which is the case in our
    CI system), add the new tarball into local.conf
    
    On release stage, publish also the examples tarball to S3.
