### PR TITLE
yocto build: Fix pipeline for release branches with no mender-gateway

### DIFF
--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -28,10 +28,10 @@ build:client:qemu:
     - mkdir -p stage-artifacts
     - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
     - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
-    - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
+    - if [[ -d $WORKSPACE/go/src/github.com/mendersoftware/monitor-client ]] && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
     -   docker save registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:pr -o stage-artifacts/mender-monitor-qemu-commercial.tar
     - fi
-    - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
+    - if [[ -d $WORKSPACE/go/src/github.com/mendersoftware/mender-gateway ]] && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
     -   docker save registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:pr -o stage-artifacts/mender-gateway-qemu-commercial.tar
     - fi
   after_script:


### PR DESCRIPTION
We need to check both, that the recipe exists and that we actually have
the pre-build package (iow that the component exists in the workspace).