### PR TITLE
chore: point the build-master role description to the qastatus page

### DIFF
--- a/Documentation/build-master-role.md
+++ b/Documentation/build-master-role.md
@@ -17,7 +17,7 @@ This is the Google calendar that shows who takes this role when.
 
 ### Nightly Mender QA build
 
-Link: https://gitlab.com/Northern.tech/Mender/mender-qa/pipeline_schedules
+Link:  https://qastatus.mender.io/build-status
 
 There is no golden rule on what to do when the "Last Pipeline" in the link above
 is not green.
@@ -48,7 +48,7 @@ where a new Hosted Mender release is planned.
 
 ### Individual pipelines
 
-Link: https://northern.tech.gitlab.io/Mender/mender-build-status/
+Link: https://qastatus.mender.io/nightlies
 
 All should be green. If a pipeline is broken, ping the corresponding team.
 


### PR DESCRIPTION
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>