### PR TITLE
chore: set TESTS_IN_PARALLEL to 2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -70,7 +70,7 @@ variables:
   RUN_BACKEND_INTEGRATION_TESTS: "true"
   RUN_INTEGRATION_TESTS: "true"
   SPECIFIC_INTEGRATION_TEST: ""
-  TESTS_IN_PARALLEL: "4"
+  TESTS_IN_PARALLEL: "2"
 
   # Child pipelines build and test
   MENDER_CONVERT_REV: "master"


### PR DESCRIPTION
Nightlies demonstrated that TESTS_IN_PARALLEL set to 2 increases the
stability of the tests. Let's set it as the new default.

Changelog: none
Ticket: None

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>