### PR TITLE
fix: Don't fail when first feature expansion attempt fails.

### DIFF
--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -495,7 +495,7 @@ build_and_test_client() {
         clean_build_config
         bitbake $images_to_build
         if ${BUILD_DOCKER_IMAGES:-false}; then
-            features=`bitbake -e $image_name | egrep '^MENDER_FEATURES='`
+            features=`bitbake -e $image_name | egrep '^MENDER_FEATURES=' || true`
             # fall back to DISTRO_FEATURES if we found no MENDER_FEATURES
             [[ "$features" == "" ]] && features=`bitbake -e $image_name | egrep '^DISTRO_FEATURES='`
             egrep -q '\bmender-image-uefi\b' <<<${features} && extension="uefiimg"


### PR DESCRIPTION
We need to check `MENDER_FEATURES` first, then `DISTRO_FEATURES`. There is code for both, but we never get to the second attempt because the `set -e` error handling kicks in before we get there. Fix by making the statement unconditionally true.

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>