### PR TITLE
ci(trigger-packages.yml): Add missing mender-configure version

### DIFF
--- a/gitlab-pipeline/stage/trigger-images.yml
+++ b/gitlab-pipeline/stage/trigger-images.yml
@@ -4,10 +4,7 @@
     MENDER_ARTIFACT_VERSION: $MENDER_ARTIFACT_REV
     MENDER_CLIENT_VERSION: $MENDER_REV
     MENDER_ADDON_CONNECT_VERSION: $MENDER_CONNECT_REV
-    # Obs! mender-configure-module is not part of the release (from release_tool eyes)
-    # so it cannot be passed downstream to mender-convert.
-    # It is not installed in our pre-converted images, so it doesn't really matter
-    #MENDER_ADDON_CONFIGURE_VERSION
+    MENDER_ADDON_CONFIGURE_VERSION: $MONITOR_CLIENT_REV
 
     # Mode: "build and publish" or "build and test"
     TEST_MENDER_CONVERT: $TEST_MENDER_CONVERT


### PR DESCRIPTION
Which nowadays is part of the release tool.