### PR TITLE
QA-352: ci: Do not inherit parent variables on child pipelines

### DIFF
--- a/gitlab-pipeline/stage/trigger-images.yml
+++ b/gitlab-pipeline/stage/trigger-images.yml
@@ -1,5 +1,7 @@
 .template:trigger:mender-convert:
   stage: trigger:images
+  inherit:
+    variables: false
   variables:
     MENDER_ARTIFACT_VERSION: $MENDER_ARTIFACT_REV
     MENDER_CLIENT_VERSION: $MENDER_REV

--- a/gitlab-pipeline/stage/trigger-packages.yml
+++ b/gitlab-pipeline/stage/trigger-packages.yml
@@ -1,5 +1,7 @@
 trigger:mender-dist-packages:
   stage: trigger:packages
+  inherit:
+    variables: false
   needs: []
   rules:
     - if: $BUILD_MENDER_DIST_PACKAGES == "true"

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -111,6 +111,9 @@ def generate(integration_repo, args):
 
         document[job_key] = {
             "stage": stage_name,
+            "inherit": {
+                "variables": False,
+            },
             "trigger": {
                 "project": "Northern.tech/Mender/mender-qa",
                 "branch": "master",


### PR DESCRIPTION
So that we have full control of which variables to pass downstream by opting-in explicitly the required ones.

See: https://docs.gitlab.com/ee/ci/yaml/#inherit