### PR TITLE
chore: add o+rw permissions to /dev/kvm

### DIFF
--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -27,6 +27,8 @@
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
     # Enable nesting VMs
     - modprobe -r kvm_intel && modprobe kvm_intel nested=Y
+    # Give other users read and write access to the KVM device
+    - chmod o+rw /dev/kvm
     # Enable NFS cache for yocto
     - mount.nfs4 ${SSTATE_CACHE_INTRNL_ADDR}:/sstate-cache /mnt/sstate-cache
     # Traps only work if executed in a sub shell.

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -162,6 +162,9 @@ test:backend-integration:enterprise:
     - unset DOCKER_TLS_VERIFY
     - unset DOCKER_CERT_PATH
 
+    # Make sure the /dev/kvm device is readable and writable by everyone
+    - chmod o+rw /dev/kvm
+
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.gz build_revisions.env stage-artifacts /tmp

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -363,6 +363,14 @@ init_environment() {
         exit 1
     fi
 
+    if [ ! -w /dev/kvm ] || [ ! -r /dev/kvm ]; then
+        echo "/dev/kvm is not properly configured for user: $(whoami)"
+        echo "user groups: $(groups)"
+        echo "$(ls -l /dev/kvm)"
+        echo "the tests need read and write access to the KVM device"
+        exit 1
+    fi
+
     # Clean up build slave.
     if [ "$CLEAN_BUILD_CACHE" = "true" ]
     then


### PR DESCRIPTION
build-host `/etc/group` and docker container `/etc/group` does not necessarily match for the `kvm` group which is set on the `/dev/kvm` device.

Workaround is simple: just allow all read and write permissions on the device.

We don't process any sensitive stuff here.

Ticket: QA-414

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>