### PR TITLE
fix(mantra): Make the curl call follow redirects

### DIFF
--- a/scripts/mantra_post_test_results
+++ b/scripts/mantra_post_test_results
@@ -24,6 +24,7 @@ builds_endpoint=https://qastatus.mender.io/api/projects/${project_id}/builds
 
 rm -f output
 curl -f --user ${MANTRA_USERNAME}:${MANTRA_PASSWORD} \
+        -L \
         -H "Content-Type: application/json" \
         -d "$request_body" \
         -o output \
@@ -37,6 +38,7 @@ build_id=$(cat output | jq .id)
 results_endpoint=https://qastatus.mender.io/api/projects/${project_id}/builds/${build_id}/results
 
 curl -f --user ${MANTRA_USERNAME}:${MANTRA_PASSWORD} \
+        -L \
         -H "Content-Type: application/xml" \
         --data-binary @$results_file \
         "$results_endpoint"


### PR DESCRIPTION
With the google auth now in place, the call now needs to follow redirects in order to post test results to Mantra.

Changelog: None
Ticket: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>