### PR TITLE
feat(image-rofs-commercial): Adds rofs-commercial binary delta img

### DIFF
--- a/Documentation/test-suites-overview.md
+++ b/Documentation/test-suites-overview.md
@@ -122,7 +122,7 @@ ubifs). Following is a list of the current platforms under test:
 * beagleboneblack
 * qemux86-64-bios-grub-gpt
 * qemux86-64-bios-grub
-* vexpress-qemu-uboot-uefi-grub  
+* vexpress-qemu-uboot-uefi-grub
 
 ### Running locally
 

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -111,7 +111,7 @@ build:servers:
 
     - mkdir -p stage-artifacts
     - for image in $(${CI_PROJECT_DIR}/../integration/extra/release_tool.py -l docker); do
-    -   if ! echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway|generate-delta-worker'; then
+    -   if ! echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway|generate-delta-worker'; then
     -     docker_url=$(${CI_PROJECT_DIR}/../integration/extra/release_tool.py --map-name docker $image docker_url)
     -     docker save $docker_url:pr -o stage-artifacts/${image}.tar
     -   fi

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -36,7 +36,7 @@ test:backend-integration:open_source:
 
     # Load all docker images except client
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if ! echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
+    -   if ! echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway'; then
     -     docker load -i stage-artifacts/${image}.tar
     -   fi
     - done

--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -34,6 +34,9 @@ build:client:qemu:
     - if [[ -d $WORKSPACE/go/src/github.com/mendersoftware/mender-gateway ]] && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
     -   docker save registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:pr -o stage-artifacts/mender-gateway-qemu-commercial.tar
     - fi
+    - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb ]]; then
+    -   docker save registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:pr -o stage-artifacts/mender-qemu-rofs-commercial.tar
+    - fi
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi

--- a/scripts/servers-build.sh
+++ b/scripts/servers-build.sh
@@ -51,7 +51,7 @@ build_servers_repositories() {
                     :
                     ;;
 
-                mender-monitor-qemu-commercial|mender-gateway-qemu-commercial)
+                mender-monitor-qemu-commercial|mender-gateway-qemu-commercial|mender-qemu-rofs-commercial)
                     # Built in yocto-build-and-test.sh::build_and_test_client
                     :
                     ;;

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -507,6 +507,9 @@ build_and_test_client() {
                     && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
                 images_to_build+=" mender-gateway-image-full-cmdline"
             fi
+            if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb ]]; then
+                images_to_build+=" mender-image-full-cmdline-rofs-commercial"
+            fi
         fi
 
         # Build once with clean_build_config enabled and keep a copy.
@@ -522,6 +525,7 @@ build_and_test_client() {
 
             copy_clean_image "${machine_name}" "${board_name}" "${image_name}" "${device_type}" "$extension"
             copy_clean_image "${machine_name}" "${board_name}" "mender-image-full-cmdline-rofs" "${device_type}" "$extension"
+            copy_clean_image "${machine_name}" "${board_name}" "mender-image-full-cmdline-rofs-commercial" "${device_type}" "$extension"
             copy_clean_image "${machine_name}" "${board_name}" "mender-monitor-image-full-cmdline" "${device_type}" "$extension"
             copy_clean_image "${machine_name}" "${board_name}" "mender-gateway-image-full-cmdline" "${device_type}" "$extension"
         fi
@@ -580,6 +584,19 @@ build_and_test_client() {
                 $WORKSPACE/integration/extra/release_tool.py \
                     --set-version-of mender-gateway-qemu-commercial \
                     --version pr || true
+            fi
+
+            if grep mender-image-full-cmdline-rofs-commercial <<<"$images_to_build"; then
+                filename="clean-mender-image-full-cmdline-rofs-commercial-${machine_name}.${extension}"
+
+                $WORKSPACE/meta-mender/meta-mender-qemu/docker/build-docker \
+                    -I "${BUILDDIR}/tmp/deploy/images/${machine_name}/${filename}.gz" \
+                    -i mender-image-full-cmdline-rofs-commercial \
+                    $machine_name \
+                    -t registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:pr
+                $WORKSPACE/integration/extra/release_tool.py \
+                    --set-version-of mender-qemu-rofs-commercial \
+                    --version pr
             fi
         fi
 

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -295,7 +295,7 @@ EOF
 # prepares the configuration for the so-called clean image. this is the image
 # that will be embedded in the client containers and then used in integartion tests
 # see integration/tests/run.sh
-# the main idea is to change the artifact_info and the additional targets are added 
+# the main idea is to change the artifact_info and the additional targets are added
 # in order to distinguish this image (for instance so we can recognize it from
 # the inside in the tests)
 clean_build_config() {


### PR DESCRIPTION
This adds the ability to build the `mender-image-full-cmdline-rofs-commercial` yocto image and package it in a qemu container.

Changelog: None
Ticket: MEN-6004

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>