### PR TITLE
fix: Add missing image in the filter expression

### DIFF
--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -529,7 +529,7 @@ release_docker_images:automatic:client-only:
     -   VERSION_TYPE_PARAMS="--version-type docker"
     - fi
     # Load, tag and push mender-client-* images
-    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-monitor|mender-gateway'); do
+    - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-qemu|mender-monitor|mender-gateway'); do
         version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
         docker load -i stage-artifacts/${image}.tar;

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -220,7 +220,7 @@ test:backend-integration:azblob:enterprise:
 
     # Load all docker images, and the client images depending on $BUILD_CLIENT
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
+    -   if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
     -       docker load -i stage-artifacts/${image}.tar
     -     else
@@ -235,7 +235,7 @@ test:backend-integration:azblob:enterprise:
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io
     # Set testing versions to PR
     - for image in $(integration/extra/release_tool.py -l docker); do
-    -   if echo $image | egrep -q 'mender-client|mender-monitor|mender-gateway'; then
+    -   if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
     -       integration/extra/release_tool.py --set-version-of $image --version pr
     -     else


### PR DESCRIPTION
When running pipelines with pre-built client, we need to skip this new image the same way we do for the rest. Add it also for `release_docker_images` job.

Amends commit 2baa003e437f6974e78cdc32fb9b8ea8cc46403b.