### PR TITLE
ci: Add openssl1.1-compat package on integration tests

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -218,6 +218,9 @@ test:backend-integration:azblob:enterprise:
     - apk add $(cat ${WORKSPACE}/integration/tests/requirements/apk-requirements.txt)
     - pip install -r ${WORKSPACE}/integration/tests/requirements/python-requirements.txt
 
+    # QA-507: Install OpenSSL 1.1 compatibility package while we redesign this dependency
+    - apk add openssl1.1-compat-dev
+
     # Load all docker images, and the client images depending on $BUILD_CLIENT
     - for image in $(integration/extra/release_tool.py -l docker); do
     -   if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway'; then


### PR DESCRIPTION
Latest `docker:dind` image comes only with openssl 3.

We are working on a plan to upgrade the whole ecosystem, but meanwhile let's have in the compatibility package to keep CI running.

Ticket: QA-507