### PR TITLE
QA-508: ci: Increase robustness for dockerd wait

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -206,7 +206,8 @@ test:backend-integration:azblob:enterprise:
     # Wait for dockerd to start
     - |-
       MAX_WAIT=30
-      while [ ! -e "/var/run/docker.sock" ] && [ $MAX_WAIT -gt 0 ]; do
+      while [ $MAX_WAIT -gt 0 ]; do
+        docker version && break
         MAX_WAIT=$(($MAX_WAIT - 1))
         sleep 1
       done


### PR DESCRIPTION
We are seeing failures when `/var/run/docker.sock` exists but dockerd did not correctly start up. Use a docker command instead to break the loop to give it more time.