### PR TITLE
ci: Revert "ci: Pin integration tests base image to Alpine 3.16"

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -171,8 +171,7 @@ test:backend-integration:azblob:enterprise:
   stage: test
   # Integration tests depends on running ssh to containers, we're forced to
   # run dockerd on the same host.
-  # QA-507: Pin to Alpine 3.16 to have OpenSSL 1.1 compatibility while we redesign this dependency
-  image: docker:20.10.21-dind-alpine3.16
+  image: docker:dind
   variables:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300


### PR DESCRIPTION
This reverts commit b3f550f2ebd71c9fa5d0c704efbab862e333ea08.