### PR TITLE
QA-487: feat: Split out cross-platform tests

### DIFF
--- a/gitlab-pipeline/stage/publish-tests.yml
+++ b/gitlab-pipeline/stage/publish-tests.yml
@@ -122,14 +122,14 @@ publish:tests:acceptance:vexpress_qemu:uboot_uefi_grub:
   variables:
     JOB_BASE_NAME: vexpress_qemu_uboot_uefi_grub
 
-publish:tests:acceptance:vexpress_qemu_flash:
+publish:tests:acceptance:vexpress_qemu:flash:
   extends: .template_publish_acceptance_coverage
   except:
     variables:
       - $TEST_VEXPRESS_QEMU_FLASH != "true"
   needs:
     - init:workspace
-    - test:acceptance:vexpress_qemu_flash
+    - test:acceptance:vexpress_qemu:flash
   variables:
     JOB_BASE_NAME: vexpress_qemu_flash
 

--- a/gitlab-pipeline/stage/publish-tests.yml
+++ b/gitlab-pipeline/stage/publish-tests.yml
@@ -78,6 +78,18 @@ publish:tests:acceptance:qemux86_64:uefi_grub:
   variables:
     JOB_BASE_NAME: qemux86_64_uefi_grub
 
+publish:tests:acceptance:qemux86_64:uefi_grub:cross-platform:
+  extends: .template_publish_acceptance_coverage
+  except:
+    variables:
+      - $TEST_QEMUX86_64_UEFI_GRUB != "true"
+  needs:
+    - init:workspace
+    - test:acceptance:qemux86_64:uefi_grub:cross-platform
+  variables:
+    # Modify JOB_BASE_NAME to have a different flag when reporting coverage
+    JOB_BASE_NAME: qemux86_64_uefi_grub-cross-platform
+
 publish:tests:acceptance:vexpress_qemu:
   extends: .template_publish_acceptance_coverage
   except:

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -205,7 +205,7 @@ release_board_artifacts:vexpress-qemu-uboot-uefi-grub:automatic:
 # release_board_artifacts:vexpress-qemu-flash:manual:
 #   dependencies:
 #     - init:workspace
-#     - test:acceptance:vexpress_qemu_flash
+#     - test:acceptance:vexpress_qemu:flash
 #   when: manual
 #   only:
 #     variables:
@@ -215,7 +215,7 @@ release_board_artifacts:vexpress-qemu-uboot-uefi-grub:automatic:
 # release_board_artifacts:vexpress-qemu-flash:automatic:
 #   dependencies:
 #     - init:workspace
-#     - test:acceptance:vexpress_qemu_flash
+#     - test:acceptance:vexpress_qemu:flash
 #   only:
 #     variables:
 #       - $PUBLISH_RELEASE_AUTOMATIC == "true" && $BUILD_VEXPRESS_QEMU_FLASH == "true"

--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -320,7 +320,7 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
 # Note that vexpress-qemu-flash configuration does not generate an ext4 image so
 # the build script does not generate the Mender Artifact neither. This job
 # collects the .ubifs for debugging but not for release publishing
-test:acceptance:vexpress_qemu_flash:
+test:acceptance:vexpress_qemu:flash:
   only:
     variables:
       - $BUILD_VEXPRESS_QEMU_FLASH == "true"

--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -10,6 +10,7 @@ variables:
   MANTRA_ID_backend_integration_enterprise: "8"
   MANTRA_ID_full_integration_open_source: "9"
   MANTRA_ID_full_integration_enterprise: "10"
+  MANTRA_ID_accep_qemux86_64_uefi_grub_cross_platform: "11"
 
 build:client:qemu:
   only:
@@ -66,6 +67,7 @@ test:acceptance:qemux86_64:uefi_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
@@ -109,6 +111,58 @@ test:acceptance:qemux86_64:uefi_grub:
     reports:
       junit: results_accep_qemux86_64_uefi_grub.xml
 
+test:acceptance:qemux86_64:uefi_grub:cross-platform:
+  only:
+    variables:
+      - $TEST_QEMUX86_64_UEFI_GRUB == "true"
+  stage: yocto:build-n-test
+  extends: .template_build_test_acc
+  variables:
+    JOB_BASE_NAME: mender_qemux86_64_uefi_grub
+    CROSS_PLATFORM_TESTS_ARG: "--only-cross-platform-tests"
+  script:
+    - cd ${CI_PROJECT_DIR}
+    - mkdir -p stage-artifacts
+    - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
+  after_script:
+    - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
+    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+
+    - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub_cross_platform.xml
+    -   cp $WORKSPACE/meta-mender/tests/acceptance/report.html report_accep_qemux86_64_uefi_grub_cross_platform.html
+    - fi
+
+    - if [ "$NIGHTLY_BUILD" = "true" ]; then
+    -   build_name=nightly-$(date +%Y-%m-%d)
+    - else
+    -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
+    - fi
+    - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
+        $MANTRA_ID_accep_qemux86_64_uefi_grub_cross_platform
+        $build_name
+        results_accep_qemux86_64_uefi_grub_cross_platform.xml || true
+
+    - cp /var/log/sysstat/sysstat.log .
+    - sadf sysstat.log -g -- -qurbS > sysstat.svg
+
+    - ls -lh stage-artifacts/
+    # Post job status
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
+
+  artifacts:
+    expire_in: 2w
+    when: always
+    paths:
+      - stage-artifacts/
+      - results_accep_qemux86_64_uefi_grub_cross_platform.xml
+      - report_accep_qemux86_64_uefi_grub_cross_platform.html
+      - acceptance-tests-coverage
+      - sysstat.log
+      - sysstat.svg
+    reports:
+      junit: results_accep_qemux86_64_uefi_grub_cross_platform.xml
+
 test:acceptance:vexpress_qemu:
   only:
     variables:
@@ -118,6 +172,7 @@ test:acceptance:vexpress_qemu:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
@@ -170,6 +225,7 @@ test:acceptance:qemux86_64:bios_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
@@ -222,6 +278,7 @@ test:acceptance:qemux86_64:bios_grub_gpt:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_qemux86_64_bios_grub_gpt
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
@@ -274,6 +331,7 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_uboot_uefi_grub
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
@@ -329,6 +387,7 @@ test:acceptance:vexpress_qemu:flash:
   extends: .template_build_test_acc
   variables:
     JOB_BASE_NAME: mender_vexpress_qemu_flash
+    CROSS_PLATFORM_TESTS_ARG: "--no-cross-platform-tests"
   script:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -668,7 +668,8 @@ build_and_test_client() {
 
             python3 -m pytest $xdist_args --verbose --junit-xml=results.xml \
                     --bitbake-image $image_name --board-type=$board_name $pytest_args \
-                    $html_report_args $acceptance_test_to_run
+                    $html_report_args $acceptance_test_to_run \
+                    ${CROSS_PLATFORM_TESTS_ARG}
 
             cd $WORKSPACE/
         fi


### PR DESCRIPTION
    Add a new client acceptance test CI job to run (only) the cross-platform
    tests. These tests are excluded from the rest of the client acceptance
    test jobs.
