### PR TITLE
QA-508: fix(test-stage-template): dockerd start script regex improvement

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -222,7 +222,7 @@ test:backend-integration:azblob:enterprise:
         if docker version &>/dev/null; then
           docker version # Verify that the dockerd is up and running
           break
-        elif ! ps -o comm | grep -q -E "docker-init|dockerd|containerd"; then
+        elif ! ps -o comm | grep -q -E "docker-init|dockerd|containerd|dockerd-entry|dind|openssl"; then
           run_dockerd # Run dockerd if no related processes are running
         fi
         MAX_WAIT=$((${MAX_WAIT} - 1))


### PR DESCRIPTION
It's some corner cases when the dockerd start script can run another instance of entrypoint script during the execution of a first one.

Changelog: None
Ticket: QA-508
Signed-off-by: Alex Miliukov <oleksandr.miliukov@northern.tech>