### PR TITLE
docs: Update Build Master role responsibilities

### DIFF
--- a/Documentation/build-master-role.md
+++ b/Documentation/build-master-role.md
@@ -18,7 +18,7 @@ This is the Google calendar that shows who takes this role when.
 ### Nightly Mender QA build
 
 Link: https://qastatus.mender.io/nightlies
-Link: https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipeline_schedules
+Link: https://gitlab.com/Northern.tech/Mender/mender-qa/-/pipelines?page=1&scope=all&source=schedule
 
 There is no golden rule on what to do when the "Last Pipeline" in the link above
 is not green.
@@ -29,7 +29,7 @@ for actual test failures we need to asses if it might be a regression or not.
 
 ### Weekly Mender integration tests on staging
 
-Link: https://gitlab.com/Northern.tech/Mender/integration/-/pipeline_schedules
+Link: https://gitlab.com/Northern.tech/Mender/integration/-/pipelines?page=1&scope=all&source=schedule
 
 Every Monday evening, at 9 PM UTC, we run the Mender integration tests targeting
 the Mender staging environment.

--- a/Documentation/build-master-role.md
+++ b/Documentation/build-master-role.md
@@ -15,6 +15,16 @@ This is the Google calendar that shows who takes this role when.
 
 ## Responsibilities
 
+### Overview of unstable tests
+
+Link: https://qastatus.mender.io/stats
+
+The unstable tests should be known to the Build Master so that it can be detected when
+test failures are genuine or spurious.
+
+By the end of the Build Master period, all failed tests in nightly builds (link above)
+should either be fixed or reported in JIRA tasks to follow-up in the next period.
+
 ### Nightly Mender QA build
 
 Link: https://qastatus.mender.io/nightlies


### PR DESCRIPTION
Following up action point from Mender QA meeting 2023-01-15.


Bonus:

* docs: Update links for GitLab scheduled pipelines
    Now that `/pipelines` support filtering, these links are much more
    representative of the health of the scheduled pipeline.