### PR TITLE
QA-527: feat: Move all workloads to GCP

### DIFF
--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -1,5 +1,7 @@
 
 .template_build_test_acc:
+  tags:
+    - mender-qa-worker-client-acceptance-tests
   image: mendersoftware/mender-test-containers:mender-client-acceptance-testing
   variables:
     DOCKER_BUILDKIT: 1
@@ -7,8 +9,6 @@
     - init:workspace
     - build:mender-monitor:package
     - build:mender-gateway:package
-  tags:
-    - mender-qa-worker-client-acceptance-tests
   before_script:
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -8,6 +8,8 @@ include:
     ref: 'master'
 
 build:client:docker:
+  tags:
+    - mender-qa-worker-generic-light
   stage: build
   only:
     variables:
@@ -20,8 +22,6 @@ build:client:docker:
   image: docker
   services:
     - docker:dind
-  tags:
-    - docker
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -70,6 +70,8 @@ build:client:docker:
       - stage-artifacts/
 
 build:servers:
+  tags:
+    - mender-qa-worker-generic-heavy
   stage: build
   only:
     variables:
@@ -84,8 +86,6 @@ build:servers:
   image: docker
   services:
     - docker:dind
-  tags:
-    - mender-qa-worker-generic-heavy
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -128,6 +128,8 @@ build:servers:
       - stage-artifacts/
 
 build:mender-cli:
+  tags:
+    - mender-qa-worker-generic-light
   stage: build
   only:
     variables:
@@ -182,6 +184,8 @@ build:mender-cli:
       - stage-artifacts/
 
 build:mender-artifact:
+  tags:
+    - mender-qa-worker-generic
   stage: build
   only:
     variables:
@@ -193,8 +197,6 @@ build:mender-artifact:
   image: docker
   services:
     - docker:dind
-  tags:
-    - mender-qa-worker-generic
   needs:
     - init:workspace
   allow_failure: false
@@ -239,6 +241,8 @@ build:mender-artifact:
       - stage-artifacts/
 
 build:mender-monitor:package:
+  tags:
+    - mender-qa-worker-generic-light
   stage: build
   image: alpine:3.12
   needs: []
@@ -270,6 +274,8 @@ build:mender-monitor:package:
       - stage-artifacts
 
 build:mender-gateway:package:
+  tags:
+    - mender-qa-worker-generic-light
   stage: build
   needs:
     - init:workspace
@@ -290,6 +296,8 @@ build:mender-gateway:package:
     - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-gateway
 
 build:generate-delta-worker:docker:
+  tags:
+    - mender-qa-worker-generic-light
   stage: build
   only:
     variables:

--- a/gitlab-pipeline/stage/init-mender-monitor-package.yml
+++ b/gitlab-pipeline/stage/init-mender-monitor-package.yml
@@ -1,4 +1,6 @@
 init:mender-monitor-package:
+  tags:
+    - mender-qa-worker-generic-light
   stage: init
   image: alpine:3.12
   before_script:

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -1,5 +1,7 @@
 
 init:workspace:
+  tags:
+    - mender-qa-worker-generic-light
   stage: init
   image: alpine:3.12
   script:

--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -1,5 +1,7 @@
 
 mender-qa:success:
+  tags:
+    - mender-qa-worker-generic-light
   stage: .post
   when: on_success
   # Keep overhead low by using a small image with curl preinstalled.
@@ -10,6 +12,8 @@ mender-qa:success:
     - $CI_PROJECT_DIR/scripts/github_pull_request_status success "mender-qa pipeline passed" $CI_PIPELINE_URL ci/mender-qa
 
 mender-qa:failure:
+  tags:
+    - mender-qa-worker-generic-light
   stage: .post
   when: on_failure
   # Keep overhead low by using a small image with curl preinstalled.
@@ -21,6 +25,8 @@ mender-qa:failure:
 
 
 .coveralls:finish-build:
+  tags:
+    - mender-qa-worker-generic-light
   stage: .post
   # See https://docs.coveralls.io/parallel-build-webhook
   variables:

--- a/gitlab-pipeline/stage/pre.yml
+++ b/gitlab-pipeline/stage/pre.yml
@@ -1,5 +1,7 @@
 
 mender-qa:start:
+  tags:
+    - mender-qa-worker-generic-light
   stage: .pre
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl

--- a/gitlab-pipeline/stage/publish-tests.yml
+++ b/gitlab-pipeline/stage/publish-tests.yml
@@ -3,6 +3,8 @@
 # * running tests for a mender PR: MENDER_REV ~= /pull/XXX/head/
 # * running nightly build: $NIGHTLY_BUILD == "true"
 .template_publish_acceptance_coverage:
+  tags:
+    - mender-qa-worker-generic-light
   only:
     variables:
       - $MENDER_REV =~ /pull\/.*\/head/

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -1,5 +1,7 @@
 
 .template_release_docker_images:
+  tags:
+    - mender-qa-worker-generic-light
   only:
     variables:
       - ($BUILD_SERVERS == "true" && $BUILD_CLIENT == "true") || $RUN_INTEGRATION_TESTS == "true"
@@ -56,6 +58,8 @@ release_docker_images:automatic:
   extends: .template_release_docker_images
 
 .template_release_board_artifacts:
+  tags:
+    - mender-qa-worker-generic-light
   # Jobs including this template must define PUBLISH_BOARD_NAME and set up dependencies
   stage: release
   image: debian:buster
@@ -309,6 +313,8 @@ release_board_artifacts:raspberrypi4:automatic:
   }
 
 .template_release_binary_tools:
+  tags:
+    - mender-qa-worker-generic-light
   # Jobs including this template must set either "dependencies" or "needs"
   # for "init:workspace", "build:mender-cli" and "build:mender-artifact".
   only:
@@ -409,6 +415,8 @@ release_binary_tools:automatic:
   extends: .template_release_binary_tools
 
 .template_release_mender-monitor:
+  tags:
+    - mender-qa-worker-generic-light
   stage: release
   image: debian:buster
   variables:
@@ -447,6 +455,8 @@ release_mender-monitor:automatic:
   extends: .template_release_mender-monitor
 
 .template_release_mender-gateway:
+  tags:
+    - mender-qa-worker-generic-light
   stage: release
   image: debian:buster
   variables:
@@ -494,6 +504,8 @@ release_mender-gateway:automatic:
 # Do not confuse with release_docker_images which publishes all images
 # (including client ones) used during releases.
 release_docker_images:automatic:client-only:
+  tags:
+    - mender-qa-worker-generic-light
   only:
     variables:
       - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -1,5 +1,7 @@
 
 test:backend-integration:open_source:
+  tags:
+    - mender-qa-worker-backend-integration-tests
   rules:
   - if: '$RUN_BACKEND_INTEGRATION_TESTS == "true"'
     when: always
@@ -9,8 +11,6 @@ test:backend-integration:open_source:
     TEST_SUITE: "open"
   services:
     - docker:dind
-  tags:
-    - mender-qa-worker-backend-integration-tests
   needs:
     - init:workspace
     - build:servers
@@ -176,6 +176,8 @@ test:backend-integration:azblob:enterprise:
     AZURE_STORAGE_CONTAINER_PREFIX: "backend-ent"
 
 .integration_setup_template:
+  tags:
+    - mender-qa-worker-integration-tests
   stage: test
   # Integration tests depends on running ssh to containers, we're forced to
   # run dockerd on the same host. It prevents us from using GitLab service,
@@ -189,8 +191,6 @@ test:backend-integration:azblob:enterprise:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
     TEST_SUITE: "open"
-  tags:
-    - mender-qa-worker-integration-tests
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt


### PR DESCRIPTION
By using existing tag `mender-qa-worker-generic-light`.

For consistency across files, all `tags` keys for all jobs have been moved at the beginning of the yaml object.