### PR TITLE
chore: Set empty dependencies for ci jobs in .post stage

### DIFF
--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -3,6 +3,7 @@ mender-qa:success:
   tags:
     - mender-qa-worker-generic-light
   stage: .post
+  dependencies: []
   when: on_success
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
@@ -15,6 +16,7 @@ mender-qa:failure:
   tags:
     - mender-qa-worker-generic-light
   stage: .post
+  dependencies: []
   when: on_failure
   # Keep overhead low by using a small image with curl preinstalled.
   image: appropriate/curl
@@ -28,6 +30,7 @@ mender-qa:failure:
   tags:
     - mender-qa-worker-generic-light
   stage: .post
+  dependencies: []
   # See https://docs.coveralls.io/parallel-build-webhook
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"


### PR DESCRIPTION
This shortcut should speed up the status report jobs.

The default behavior is to get all dependencies from all previous stages, which for this last stage translates to almost 4 minutes of downloading everything.

We cannot use `needs` as we still want it to run at the end of the pipeline.