### PR TITLE
MEN-6142: Do not skip `do_patch` for recipes using `externalsrc`

### DIFF
--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -658,10 +658,13 @@ build_and_test_client() {
             pytest_args="$pytest_args --commercial-tests"
 
             local xdist_args
-            # Use the exclusivity fixture as a sign that this branch supports
-            # running tests in parallel with xdist.
+            local cross_args
+            # Use the exclusivity fixture as a sign that this branch support modern
+            # features of mender-image-tests: running tests in parallel and filtering
+            # cross platform tests
             if ( cd image-tests && git grep -q '^def exclusivity' ); then
                 xdist_args="-n $TESTS_IN_PARALLEL_CLIENT_ACCEPTANCE"
+                cross_args="${CROSS_PLATFORM_TESTS_ARG}"
             else
                 xdist_args="-p no:xdist"
             fi
@@ -669,7 +672,7 @@ build_and_test_client() {
             python3 -m pytest $xdist_args --verbose --junit-xml=results.xml \
                     --bitbake-image $image_name --board-type=$board_name $pytest_args \
                     $html_report_args $acceptance_test_to_run \
-                    ${CROSS_PLATFORM_TESTS_ARG}
+                    ${cross_args}
 
             cd $WORKSPACE/
         fi

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -213,11 +213,7 @@ PREFERRED_PROVIDER_virtual/mender-client-native = "mender-native"
 EOF
     fi
 
-    # Assuming sumo or newer
     cat >> $BUILDDIR/conf/local.conf <<EOF
-# MEN-2948: Renamed mender recipe -> mender-client
-# But the "mender" reference has to be kept for backwards compatibility
-# with 2.1.x, 2.2.x, and 2.3.x
 EXTERNALSRC${sep}pn-mender = "$WORKSPACE/go${BUILD_CPP_CLIENT_PATH:-}"
 EXTERNALSRC${sep}pn-mender-native = "$WORKSPACE/go${BUILD_CPP_CLIENT_PATH:-}"
 EXTERNALSRC${sep}pn-mender-client = "$WORKSPACE/go"

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -221,6 +221,10 @@ EXTERNALSRC${sep}pn-mender-client-native = "$WORKSPACE/go"
 EXTERNALSRC${sep}pn-mender-artifact = "$WORKSPACE/go"
 EXTERNALSRC${sep}pn-mender-artifact-native = "$WORKSPACE/go"
 EXTERNALSRC${sep}pn-mender-connect= "$WORKSPACE/go"
+
+# When using externalsrc from CI, we still want to apply patches
+SRCTREECOVEREDTASKS${sep}remove = "do_patch"
+
 EOF
 
     # Use network cache if present, if not, use local cache.


### PR DESCRIPTION
    chore: Remove obsolete and misleading comment
    
    Even when old branches went out of support, we still need the `mender`
    and `mender-native` for the new virtual targets (from the C++ rewrite
    project).


    fix(yocto): Do not skip `do_patch` for recipes using `externalsrc`
    
    See comment. The motivation is that we are adding some patches for
    `mender-artifact` that are being ignored by CI without this fix. It
    should be harmless for the rest of cases.
