### PR TITLE
ci: Add missing dependency for release jobs.

### DIFF
--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -12,6 +12,7 @@
   dependencies:
     - init:workspace
     - build:servers
+    - build:generate-delta-worker:docker
     - build:client:qemu
     - build:client:docker
   before_script:


### PR DESCRIPTION
Missing from commit 1afdbaac.