### PR TITLE
test: Print hostname when waiting on a build host.

### DIFF
--- a/scripts/maybe-wait-in-stage.sh
+++ b/scripts/maybe-wait-in-stage.sh
@@ -11,6 +11,6 @@ if [ "$(eval echo \"\$$1\")" = "true" ]; then
 fi
 
 while [ -f "$2" ]; do
-    echo "Waiting indefinitely until $2 is removed."
+    echo "Waiting indefinitely until $2 is removed. Hostname: $(hostname)"
     sleep 10
 done


### PR DESCRIPTION
This makes it easier to identify the host in the cloud provider, in order to log in.