### PR TITLE
chore: pyyaml install in the generate delta worker build phase

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -316,7 +316,7 @@ build:generate-delta-worker:docker:
     - build:mender-artifact
   allow_failure: false
   before_script:
-    - apk --update --no-cache add bash curl aws-cli xz
+    - apk --update --no-cache add bash curl aws-cli xz py3-yaml
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - mv workspace.tar.xz /tmp
     - mkdir -p "${WORKSPACE}"


### PR DESCRIPTION
started failing on Thursday:

```
$ ${WORKSPACE}/integration/extra/release_tool.py -l
PyYAML missing, try running 'sudo pip3 install pyyaml'.
```

Ticket: None