### PR TITLE
ci: Build with latest (master) `mender-flash`

### DIFF
--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -213,6 +213,10 @@ EOF
 PREFERRED_PROVIDER_virtual/mender-client = "mender"
 PREFERRED_PROVIDER_virtual/mender-client-native = "mender-native"
 EOF
+        # Remove after MEN-6279
+        cat >> $BUILDDIR/conf/local.conf <<EOF
+PREFERRED_VERSION:pn-mender-flash = "master-git%"
+EOF
     fi
 
     cat >> $BUILDDIR/conf/local.conf <<EOF


### PR DESCRIPTION
As we don't yet have an stable release, we need to ask CI to use latest master otherwise it defaults to an old hardcoded commit.