### PR TITLE
ci: update docker image used for building mender-cli

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -136,7 +136,7 @@ build:mender-cli:
       - $BUILD_SERVERS == "true"
       - $RUN_BACKEND_INTEGRATION_TESTS == "true"
       - $RUN_INTEGRATION_TESTS == "true"
-  image: golang:1.18-alpine3.15
+  image: golang:1.20-alpine3.18
   needs:
     - init:workspace
   allow_failure: false


### PR DESCRIPTION
With recent dependency update in the mender-cli, the tool needs to be build with golang >= 1.20