### PR TITLE
ci: Pin integration tests image to Alpine 3.18

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -186,7 +186,7 @@ test:backend-integration:azblob:enterprise:
   # when with used by GitLab network driver network connection between those
   # containers is denied (it might work locally on Linux host because of the
   # default bridge driver).
-  image: docker:dind
+  image: docker:24.0.7-dind-alpine3.18
   variables:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300


### PR DESCRIPTION
Which still provides an OpenSSL 1.1 compatibility package, required for `mender-artifact`.