### PR TITLE
ENT-11166: Added script and CFEngine policy to setup packages/software on CI build hosts

### DIFF
--- a/scripts/cfengine-build-host-setup.cf
+++ b/scripts/cfengine-build-host-setup.cf
@@ -1,0 +1,207 @@
+body file control
+{
+  inputs => { "$(sys.libdir)/stdlib.cf" };
+}
+
+bundle agent cfengine_build_host_setup
+{
+  meta:
+    "assumptions" string => "The operating system has working repository lists and has been updated and upgraded recently.";
+
+  packages:
+    debian_9|debian_10::
+      "python-psycopg2";
+    debian_11|debian_12::
+      "python3-psycopg2";
+    ubuntu_16::
+      "systemd-coredump" comment => "ubuntu_16 doesn't have systemd-coredump by default?";
+    ubuntu_20::
+      "autoconf" comment => "because on arm ubuntu-20 we need to reconfigure the debian-9 bootstrapped configure scripts.";
+      "shellcheck" comment => "not sure why only ubuntu-20 needed this.";
+    debian.(!debian_12.!ubuntu_22)::
+      "python" comment => "debian-12 has only python3";
+     !(debian_9|ubuntu_16).(debian|ubuntu)::
+       "default-jre" comment => "on debian10+ and ubuntu18+ this will be jdk11, good enough for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
+
+    debian|ubuntu::
+      "libltdl7" package_policy => "delete";
+      "libltdl-dev" package_policy => "delete";
+
+      "binutils";
+      "bison";
+      "build-essential";
+      "curl" comment => "added for debian-10";
+      "debhelper";
+      "dpkg-dev";
+      "expat";
+      "fakeroot";
+      "flex";
+      "gdb";
+      "libncurses5" comment => "added for debian-10";
+      "libncurses5-dev" comment => "added for debian-10";
+      "libexpat1-dev";
+      "libmodule-load-conditional-perl";
+      "libpam0g-dev";
+      "ntp";
+      "pkg-config";
+      "psmisc";
+      "python3-pip";
+      "rsync" comment => "added for debian-10";
+
+    ubuntu_16.mingw_build_host:: # for now, only ubu16 hosts mingw builds
+      "wine:i386";
+      "mingw-w64";
+
+# I attempted to arrange these packages in order of: generic (all versions) and then as if we gradually added them through time: rhel-6, 7, 8, 9...
+    suse|opensuse|sles|redhat|centos::
+      "gcc";
+      "ncurses-devel";
+      "pam-devel";
+      "rsync";
+      "make";
+      "rpm-build";
+
+    redhat|centos::
+      "expat-devel";
+      "gcc-c++";
+      "gettext";
+      "ncurses";
+      "perl-Digest-MD5";
+      "perl-Module-Load-Conditional";
+      "wget";
+
+    redhat_6|centos_6|redhat_7|centos_7::
+      "gdb";
+      "java-11-openjdk" comment => "ok for jenkins 2.426.1 https://www.jenkins.io/doc/book/platform-information/support-policy-java/index.html";
+      "ntp";
+      "pkgconfig";
+      "perl-IO-Compress";
+      "perl-JSON-PP";
+      "perl-Data-Dumper";
+      "perl-IPC-Cmd";
+      "perl-devel";
+      "python-psycopg2";
+      "xfsprogs";
+
+# note that shellcheck, fakeroot and ccache require epel-release to be installed
+    redhat_7|centos_7::
+      "epel-release";
+      "ccache";
+      "fakeroot";
+      "ShellCheck" comment => "for what purpose? and why not redhat_6? unused platform? also not rhel 8 and 9 so ???";
+
+    redhat_7|centos_7|redhat_9::
+      "python3-pip";
+
+    redhat_7|centos_7|redhat_8|centos_8|redhat_9::
+      "perl-ExtUtils-MakeMaker";
+      "psmisc";
+      "python3" comment => "what does redhat_6 get?";
+      "tmux" comment => "why?! :O";
+      "which";
+
+    redhat_8|centos_8::
+      "python2";
+      "python2-psycopg2";
+
+    redhat_8|centos_8|redhat_9::
+      "perl";
+      "pkgconf" comment => "pkgconfig renamed to pkgconf in rhel8";
+      "selinux-policy-devel" comment => "maybe add to _7 and _6?";
+      "openssl-devel";
+      "libtool-ltdl" package_policy => "delete", comment => "maybe redhat/centos 7 as well?";
+
+    redhat_9::
+      "python3-psycopg2";
+
+    suse|opensuse|sles::
+      "binutils";
+      "pam";
+      "pkg-config";
+      "patch";
+      "gdb";
+      "java-17-openjdk";
+
+
+  vars:
+    "suse_users_and_groups" slist => { "daemon", "bin", "sys" };
+
+  classes:
+    any::
+      "mingw_build_host" expression => fileexists("/etc/cfengine-mingw-build-host.flag");
+    debian_9|ubuntu_16::
+      "have_opt_jdk21" expression => fileexists("/opt/jdk-21.0.1");
+    redhat_7|centos_7|redhat_8|centos_8|redhat_9::
+      "have_development_tools" expression => returnszero("yum groups list installed | grep 'Development Tools' >/dev/null", "useshell"),
+        comment => "note: centos-7 has installed instead of --installed argument, and that works on rhel-8 and rhel-9 so go with the sub-command instead of option";
+    redhat_8|centos_8::
+      "have_fakeroot" expression => returnszero("command -v fakeroot >/dev/null", "useshell");
+
+  commands:
+    !have_opt_jdk21.(debian_9|ubuntu_16)::
+      "sh $(this.promise_dirname)/linux-install-jdk21.sh" contain => in_shell;
+    (redhat_7|centos_7|redhat_8|centos_8|redhat_9).!have_development_tools::
+      "yum groups install -y 'Development Tools'" contain => in_shell;
+    (redhat_8|centos_8).!have_fakeroot:: # special fakeroot, missing from _8 an d up?
+      "sudo rpm -iv https://kojipkgs.fedoraproject.org//packages/fakeroot/1.23/1.fc29/x86_64/fakeroot-1.23-1.fc29.x86_64.rpm https://kojipkgs.fedoraproject.org//packages/fakeroot/1.23/1.fc29/x86_64/fakeroot-libs-1.23-1.fc29.x86_64.rpm"
+        contain => in_shell;
+
+
+  classes:
+    debian_11::
+      "have_pip2" expression => fileexists("/usr/local/bin/pip");
+    ubuntu_16::
+      "have_i386_architecture" expression => strcmp(execresult("${paths.dpkg} --print-foreign-architectures", "noshell"), "i386");
+    ubuntu::
+      "have_localhost_hostname" expression => strcmp(execresult("${paths.hostname}", "noshell"), "localhost.localdomain");
+    opensuse|suse|sles::
+      "have_$(suse_users_and_groups)_group" expression => returnszero("grep $(suse_users_and_groups) /etc/group >/dev/null", "useshell");
+      "have_$(suse_users_and_groups)_user" expression => returnszero("grep '^$(suse_users_and_groups):' /etc/passwd >/dev/null", "useshell");
+
+  files:
+    debian_9::
+      "/etc/apt/sources.list.d/*"
+        delete => tidy;
+      "/etc/apt/sources.list"
+        content => "deb http://archive.debian.org/debian/ stretch main contrib non-free";
+    suse|opensuse|sles::
+      "/home/jenkins/.rpmmacros"
+        content => "%dist .suse15",
+        comment => "ensure %dist works in RPM .spec files - needed to add OS name/version to rpm filename";
+
+  commands:
+    redhat_9::
+      "sudo yum --nobest -e 0 -d 0 -y update" contain => in_shell; # 2022-11-15 rhel-9 needed --nobest in order to complete update/upgrade
+    redhat_8|redhat_9::
+      "sudo sed -ri 's/^%_enable_debug_packages/#\0/' /usr/lib/rpm/redhat/macros" contain => in_shell;
+# todo, need 2.7pip psycopg2-binary for ubuntu-20 as well?
+    debian_11.!have_pip2::
+      "wget https://bootstrap.pypa.io/pip/2.7/get-pip.py -O get-pip.py && python2 get-pip.py && pip install psycopg2-binary"
+        contain => in_shell;
+
+    ubuntu_16.!have_i386_architecture:: # mingw build host
+      "${paths.dpkg} --add-architecture i386";
+
+    ubuntu.!have_localhost_hostname::
+      "/usr/bin/hostnamectl set-hostname localhost.localdomain"
+        comment => "hack for aws ubuntu hosts having unique ip-n-n-n-n hostnames, we need localhost.localdomain";
+    !have_daemon_group.(suse|sles|opensuse)::
+      "groupadd -g 1 daemon" contain => in_shell;
+    !have_bin_group.(suse|sles|opensuse)::
+      "groupadd -g 2 bin" contain => in_shell;
+    !have_sys_group.(suse|sles|opensuse)::
+      "groupadd -g 3 sys" contain => in_shell;
+    !have_daemon_user.(suse|sles|opensuse)::
+      "useradd -u 1 daemon" contain => in_shell;
+    !have_bin_user.(suse|sles|opensuse)::
+      "useradd -u 2 bin" contain => in_shell;
+    !have_sys_user.(suse|sles|opensuse)::
+      "useradd -u 3 sys" contain => in_shell;
+
+# skip /etc/hosts change for now, seems kind of wrong and corrupts ip6 entries like `::1 ip6-ip6-loopback`
+# maybe the following is needed to silence such errors as:     ubuntu-16-mingw-j1: sudo: unable to resolve host localhost.localdomain
+#    ubuntu::
+#      "${paths.sed} -ri 's/localhost //' /etc/hosts";
+}
+# todo, maybe need
+# ubuntu16-mingw: echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections

--- a/scripts/linux-install-jdk21.sh
+++ b/scripts/linux-install-jdk21.sh
@@ -1,0 +1,15 @@
+# install jdk "manually"
+# depending on os, might want to do something like `apt remove default-jre openjdk-*-jre-*`
+cd /opt
+wget https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz
+echo "7e80146b2c3f719bf7f56992eb268ad466f8854d5d6ae11805784608e458343f openjdk-21.0.1_linux-x64_bin.tar.gz" > openjdk-21.0.1_linux-x64_bin.tar.gz.sha256
+sha256sum --check openjdk-21.0.1_linux-x64_bin.tar.gz.sha256
+sudo tar xf openjdk-21.0.1_linux-x64_bin.tar.gz
+sudo tee /etc/profile.d/jdk.sh << EOF
+export JAVA_HOME=/opt/jdk-21.0.1
+export PATH=\$PATH:\$JAVA_HOME/bin
+EOF
+sudo chown -R root:jenkins /opt/jdk-21.0.1
+sudo chmod -R g+rx /opt/jdk-21.0.1
+sudo update-alternatives --install /usr/bin/java java /opt/jdk-21.0.1/bin/java 1
+cd -

--- a/scripts/setup-cfengine-build-host.sh
+++ b/scripts/setup-cfengine-build-host.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+shopt -s expand_aliases
+# install needed packages and software for a build host
+set -e
+
+if command -v wget; then
+  alias urlget=wget
+elif command -v curl; then
+  alias urlget='curl -O'
+else
+  echo "Error: need something to fetch URLs. Didn't find either wget or curl."
+  exit 1
+fi
+if grep -i suse /etc/os-release; then
+  # todo check version of suse, 12 or 15
+  urlget https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.21.4/agent/agent_suse15_x86_64/cfengine-nova-3.21.4-1.suse15.x86_64.rpm
+  sudo zypper install -y cfengine-nova-3.21.4-1.suse15.x86_64.rpm
+else
+  urlget https://s3.amazonaws.com/cfengine.packages/quick-install-cfengine-enterprise.sh
+  echo "c358ca0e0dce49e8784ff2352e7c94356332ded80f5ca3903b0b3dc8d6a10cf4  quick-install-cfengine-enterprise.sh" | sha256sum --check -
+  chmod +x quick-install-cfengine-enterprise.sh
+  sudo bash ./quick-install-cfengine-enterprise.sh agent
+fi
+
+# get masterfiles
+urlget https://cfengine-package-repos.s3.amazonaws.com/enterprise/Enterprise-3.21.4/misc/cfengine-masterfiles-3.21.4-1.pkg.tar.gz
+
+echo "a4b35ad85ec14dda49b93c1c91a93e09f4336d9ee88cd6a3b27d323c90a279ca	cfengine-masterfiles-3.21.4-1.pkg.tar.gz" | sha256sum --check -
+
+tar xf cfengine-masterfiles-3.21.4-1.pkg.tar.gz
+sudo cp -a masterfiles/* /var/cfengine/inputs/
+
+# how to get the URL for the module? See cfbs code
+# _MODULES_URL = "https://archive.build.cfengine.com/modules"
+# _MODULES_URL, name, commit + ".tar.gz"
+urlget https://archive.build.cfengine.com/modules/upgrade-all-packages/e3039050296ec20c7e44b3accba84c146cf6ef69.tar.gz
+echo "ca9801c956b1bf32deb3ea6c171e6e1c685288e941e3e9e9bf4d5746445babc2  e3039050296ec20c7e44b3accba84c146cf6ef69.tar.gz" | sha256sum --check -
+tar xf e3039050296ec20c7e44b3accba84c146cf6ef69.tar.gz
+
+# upgrade all packages
+sudo cp upgrade-all-packages/upgrade_all_packages.cf /var/cfengine/inputs/services/main.cf
+sudo /var/cfengine/bin/cf-agent -KIb upgrade_all_packages_policy | tee promises.log
+grep -i error: promises.log && exit 1
+
+# run three times to ensure all is done
+policy="$(dirname "$0")"/cfengine-build-host-setup.cf
+sudo /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
+grep -i error: promises.log && exit 1
+sudo /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
+grep -i error: promises.log && exit 1
+sudo /var/cfengine/bin/cf-agent -KIf "$policy" -b cfengine_build_host_setup | tee promises.log
+grep -i error: promises.log && exit 1
+
+if command -v apt 2>/dev/null; then
+  sudo apt remove -y cfengine-nova
+  sudo rm -rf /var/cfengine /opt/cfengine /var/log/CFE*log
+elif command -v yum 2>/dev/null; then
+  sudo yum erase -y cfengine-nova
+elif command -v zypper 2>/dev/null; then
+  sudo zypper remove -n cfengine-nova
+else
+  echo "No supported package manager to uninstall cfengine."
+fi
+sudo pkill -9 cf-agent || true
+sudo pkill -9 cf-serverd || true
+sudo pkill -9 cf-monitord || true
+sudo pkill -9 cf-execd || true


### PR DESCRIPTION
Will aid in upgrading JDK for jenkins upgrade in a more sane way without having to modify many scripts in jenkins-jobs/config.xml and jenkins-vms/machines/*/Vagrantfile

Ticket: ENT-11166
