### PR TITLE
ci: Replace base image for `curl` only jobs

### DIFF
--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -6,7 +6,7 @@ mender-qa:success:
   dependencies: []
   when: on_success
   # Keep overhead low by using a small image with curl preinstalled.
-  image: appropriate/curl
+  image: curlimages/curl-base
   before_script:
     - apk --update add jq
   script:
@@ -19,7 +19,7 @@ mender-qa:failure:
   dependencies: []
   when: on_failure
   # Keep overhead low by using a small image with curl preinstalled.
-  image: appropriate/curl
+  image: curlimages/curl-base
   before_script:
     - apk --update add jq
   script:
@@ -34,7 +34,7 @@ mender-qa:failure:
   # See https://docs.coveralls.io/parallel-build-webhook
   variables:
     COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
-  image: appropriate/curl
+  image: curlimages/curl-base
   dependencies:
     - init:workspace
   before_script:

--- a/gitlab-pipeline/stage/pre.yml
+++ b/gitlab-pipeline/stage/pre.yml
@@ -4,7 +4,7 @@ mender-qa:start:
     - mender-qa-worker-generic-light
   stage: .pre
   # Keep overhead low by using a small image with curl preinstalled.
-  image: appropriate/curl
+  image: curlimages/curl-base
   before_script:
     - apk --update add jq
   script:


### PR DESCRIPTION
The previous `appropriate/curl`, although smaller, have not been updated for 6 years... running now in a problem when validating the SSL certificate of `coveralls.io`.

Replace with officially supported `curlimages/curl-base`.