### PR TITLE
ci: Correctly pass pytest option when invoking `run-sh`

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -334,7 +334,7 @@ test:backend-integration:azblob:enterprise:
         fi
     -   source ${CI_PROJECT_DIR}/build_revisions.env
     -   cd integration/tests
-    -   ./run.sh --no-download --machine-name qemux86-64
+    -   ./run.sh --no-download -- --machine-name qemux86-64
 
         # Always keep this at the end of the script stage
     -   echo "success" > /JOB_RESULT.txt


### PR DESCRIPTION
This was involuntary broken few years back when we introduced the `--` marker to pass parameters to pytest. See:
* https://github.com/mendersoftware/integration/commit/1507a9e4e73a7c1e660fc16da5231fe674fac5f6

But because the default value for the option is `qemux86-64`, it had really no implications in the testing environment.