### PR TITLE
Make meta-raspberrypi git clone optional.

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -143,7 +143,9 @@ init:workspace:
     # Add other repositories.
     - checkout_repo https://github.com/mendersoftware/mender-stress-test-client go/src/github.com/mendersoftware/mender-stress-test-client $MENDER_STRESS_TEST_CLIENT_REV
     - checkout_repo git://git.openembedded.org/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV
-    - checkout_repo https://github.com/agherzan/meta-raspberrypi.git meta-raspberrypi $META_RASPBERRYPI_REV
+    - if [ "$BUILD_RASPBERRYPI3" = true ] || [ "$BUILD_RASPBERRYPI4" = true ]; then
+    -   checkout_repo https://github.com/agherzan/meta-raspberrypi.git meta-raspberrypi $META_RASPBERRYPI_REV
+    - fi
 
     # For meta-mender we need the full git history for this logic to work:
     # https://github.com/mendersoftware/meta-mender/blob/dd0f848f260810e08b98d2a1915f734bf02a64b1/tests/acceptance/test_uboot_automation.py#L68-L83


### PR DESCRIPTION
We are moving Raspberry Pi support to meta-mender-community from scarthgap onwards, so let's save the bandwidth and artifact size when we don't need it. Dunfell and kirkstone still have the support.