### PR TITLE
QA-706: Push/Pull client images between build and test stages

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -13,6 +13,7 @@ build:client:docker:
       - $BUILD_CLIENT == "true"
   variables:
     DOCKER_BUILDKIT: 1
+    GITLAB_REGISTRY_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_ID}"
   needs:
     - init:workspace
   allow_failure: false
@@ -37,12 +38,13 @@ build:client:docker:
     - xz -d /tmp/workspace.tar.xz
     - tar -xf /tmp/workspace.tar
   script:
-    - mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
+    - echo ${CI_REGISTRY_PASSWORD} | docker login --username ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     # First build mender's repo Docker image
     - docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-client-docker docker_url)
     - cd go/src/github.com/mendersoftware/mender
     - ./tests/build-docker -t $docker_url:pr
-    - docker save $docker_url:pr -o ${CI_PROJECT_DIR}/stage-artifacts/mender-client-docker.tar
+    - docker tag ${docker_url}:pr ${GITLAB_REGISTRY_PREFIX}-mender-client-docker
+    - docker push ${GITLAB_REGISTRY_PREFIX}-mender-client-docker
     # Then, if available, build integration's repo Docker image (Mender 2.7 and later)
     - if $($WORKSPACE/integration/extra/release_tool.py -l docker | egrep -q '^mender-client-docker-addons$'); then
     -   docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-client-docker-addons docker_url)
@@ -53,18 +55,12 @@ build:client:docker:
         --build-arg MENDER_SETUP_REV=$MENDER_SETUP_REV
         --tag $docker_url:pr
         .
-    -   mkdir -p ${CI_PROJECT_DIR}/stage-artifacts
-    -   docker save $docker_url:pr -o ${CI_PROJECT_DIR}/stage-artifacts/mender-client-docker-addons.tar
+    -   docker tag ${docker_url}:pr ${GITLAB_REGISTRY_PREFIX}-mender-client-docker-addons
+    -   docker push ${GITLAB_REGISTRY_PREFIX}-mender-client-docker-addons
     - fi
     - echo "success" > /JOB_RESULT.txt
   after_script:
-    - ls -lh stage-artifacts/
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
-
-  artifacts:
-    expire_in: 2w
-    paths:
-      - stage-artifacts/
 
 build:servers:
   tags:

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -42,8 +42,13 @@
     - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker); do
         version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
-        docker load -i stage-artifacts/${image}.tar;
-        docker tag $docker_url:pr $docker_url:${version};
+        if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway-qemu-commercial'; then
+          docker pull ${GITLAB_REGISTRY_PREFIX}-${image};
+          docker tag ${GITLAB_REGISTRY_PREFIX}-${image} ${docker_url}:${version};
+        else
+          docker load -i stage-artifacts/${image}.tar;
+          docker tag ${docker_url}:pr ${docker_url}:${version};
+        fi;
         docker push $docker_url:${version};
       done
 
@@ -571,8 +576,8 @@ release_mender-gateway:automatic:
     - for image in $($WORKSPACE/integration/extra/release_tool.py --list docker | egrep 'mender-client|mender-qemu|mender-monitor|mender-gateway-qemu-commercial'); do
         version=$($WORKSPACE/integration/extra/release_tool.py --version-of $image $VERSION_TYPE_PARAMS --in-integration-version $INTEGRATION_REV);
         docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker $image docker_url);
-        docker load -i stage-artifacts/${image}.tar;
-        docker tag $docker_url:pr $docker_url:${version};
+        docker pull ${GITLAB_REGISTRY_PREFIX}-${image};
+        docker tag ${GITLAB_REGISTRY_PREFIX}-${image} ${docker_url}:${version};
         docker push $docker_url:${version};
       done
 

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -196,6 +196,7 @@ test:backend-integration:azblob:enterprise:
     DOCKER_CLIENT_TIMEOUT: 300
     COMPOSE_HTTP_TIMEOUT: 300
     TEST_SUITE: "open"
+    GITLAB_REGISTRY_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_ID}"
   before_script:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
@@ -265,15 +266,18 @@ test:backend-integration:azblob:enterprise:
     - fi
 
     # Load all docker images, and the client images depending on $BUILD_CLIENT
+    - echo ${CI_REGISTRY_PASSWORD} | docker login --username ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     - for image in $(integration/extra/release_tool.py -l docker); do
     -   if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway-qemu-commercial'; then
     -     if [ "${BUILD_CLIENT}" = "true" ]; then
-    -       docker load -i stage-artifacts/${image}.tar
+    -       docker pull ${GITLAB_REGISTRY_PREFIX}-${image}
+    -       docker tag ${GITLAB_REGISTRY_PREFIX}-${image} $(integration/extra/release_tool.py --map docker $image docker_url):pr
     -     else
     -       continue
     -     fi
+    -   else
+    -     docker load -i stage-artifacts/${image}.tar
     -   fi
-    -   docker load -i stage-artifacts/${image}.tar
     - done
 
     # Login for private repos

--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -24,19 +24,25 @@ build:client:qemu:
     JOB_BASE_NAME: mender_qemux86_64_uefi_grub
     ONLY_BUILD: "true"
     BUILD_DOCKER_IMAGES: "true"
+    GITLAB_REGISTRY_PREFIX: "${CI_REGISTRY_IMAGE}:${CI_PIPELINE_ID}"
   script:
     - cd ${CI_PROJECT_DIR}
-    - mkdir -p stage-artifacts
-    - docker save mendersoftware/mender-client-qemu:pr -o stage-artifacts/mender-client-qemu.tar
-    - docker save mendersoftware/mender-client-qemu-rofs:pr -o stage-artifacts/mender-client-qemu-rofs.tar
+    - echo ${CI_REGISTRY_PASSWORD} | docker login --username ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
+    - docker tag mendersoftware/mender-client-qemu:pr ${GITLAB_REGISTRY_PREFIX}-mender-client-qemu
+    - docker push ${GITLAB_REGISTRY_PREFIX}-mender-client-qemu
+    - docker tag mendersoftware/mender-client-qemu-rofs:pr ${GITLAB_REGISTRY_PREFIX}-mender-client-qemu-rofs
+    - docker push ${GITLAB_REGISTRY_PREFIX}-mender-client-qemu-rofs
     - if [[ -d $WORKSPACE/go/src/github.com/mendersoftware/monitor-client ]] && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-monitor-image-full-cmdline.bb ]]; then
-    -   docker save registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:pr -o stage-artifacts/mender-monitor-qemu-commercial.tar
+    -   docker tag registry.mender.io/mendersoftware/mender-monitor-qemu-commercial:pr ${GITLAB_REGISTRY_PREFIX}-mender-monitor-qemu-commercial
+    -   docker push ${GITLAB_REGISTRY_PREFIX}-mender-monitor-qemu-commercial
     - fi
     - if [[ -d $WORKSPACE/go/src/github.com/mendersoftware/mender-gateway ]] && [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-gateway-image-full-cmdline.bb ]]; then
-    -   docker save registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:pr -o stage-artifacts/mender-gateway-qemu-commercial.tar
+    -   docker tag registry.mender.io/mendersoftware/mender-gateway-qemu-commercial:pr ${GITLAB_REGISTRY_PREFIX}-mender-gateway-qemu-commercial
+    -   docker push ${GITLAB_REGISTRY_PREFIX}-mender-gateway-qemu-commercial
     - fi
     - if [[ -f $WORKSPACE/meta-mender/meta-mender-commercial/recipes-extended/images/mender-image-full-cmdline-rofs-commercial.bb ]]; then
-    -   docker save registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:pr -o stage-artifacts/mender-qemu-rofs-commercial.tar
+    -   docker tag registry.mender.io/mendersoftware/mender-qemu-rofs-commercial:pr ${GITLAB_REGISTRY_PREFIX}-mender-qemu-rofs-commercial
+    -   docker push ${GITLAB_REGISTRY_PREFIX}-mender-qemu-rofs-commercial
     - fi
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
@@ -45,14 +51,12 @@ build:client:qemu:
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-    - ls -lh stage-artifacts/
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
     paths:
-      - stage-artifacts/
       - sysstat.log
       - sysstat.svg
 


### PR DESCRIPTION
This way we utilize the existing GitLab Container registry and avoid hitting the size limits of the uploading/downloading artifacts.