### PR TITLE
ci: Correctly set only `docker` versions for integ tests

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -286,9 +286,7 @@ test:backend-integration:azblob:enterprise:
     # Set testing versions to PR
     - for image in $(integration/extra/release_tool.py -l docker); do
     -   if echo $image | egrep -q 'mender-client|mender-qemu|mender-monitor|mender-gateway-qemu-commercial'; then
-    -     if [ "${BUILD_CLIENT}" = "true" ]; then
-    -       integration/extra/release_tool.py --set-version-of $image --version pr
-    -     else
+    -     if [ "${BUILD_CLIENT}" != "true" ]; then
     -       continue
     -     fi
     -   fi

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -290,7 +290,7 @@ test:backend-integration:azblob:enterprise:
     -       continue
     -     fi
     -   fi
-    -   integration/extra/release_tool.py --set-version-of $image --version pr
+    -   integration/extra/release_tool.py --set-version-of $image --version-type docker --version pr
     - done
     # Other dependencies
     - install stage-artifacts/mender-artifact-linux /usr/local/bin/mender-artifact


### PR DESCRIPTION
In most of the cases it is the same, but for repositories that have two different docker images (for example now `mender-gateway`) we want to to set only the one pointed by `$image`.

This fixes the pipeline for prebuilt client images and https://github.com/mendersoftware/integration/pull/2603
    
