### PR TITLE
ci: Fix missing `aws-cli` package for latest Alpine

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -87,9 +87,10 @@ build:servers:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
-    - apk --update --no-cache add bash git make python3 py-pip curl jq xz aws-cli
+    - apk --update --no-cache add bash git make python3 py-pip curl jq xz
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install --break-system-packages -r requirements.txt
+    - pip3 install --break-system-packages awscli
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
     # Prepare workspace


### PR DESCRIPTION
For some unknown reason, the package has been removed for Alpine 3.20. Install it from PyPI instead.