### PR TITLE
chore: Do not run backend integration tests anymore

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ variables:
 
   # Integration and backend integration tests
   RUN_BACKEND_INTEGRATION_TESTS:
-    value: "true"
+    value: "false"
     description: |-
       Flag to run integration tests
   RUN_INTEGRATION_TESTS:


### PR DESCRIPTION
The code in the microservices repos has been freezed, so we don't need to run the tests here in regular pipelines. From now on is only needed for Mender 3.7 builds.