### PR TITLE
ci: Add missing dependency for integ tests with pre-built client

### DIFF
--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -223,6 +223,7 @@ test:integration:prebuilt_client:open_source:
     - init:workspace
     - build:mender-artifact
     - build:mender-cli
+    - build:mender-gateway:docker
 
 
 test:integration:prebuilt_client:enterprise:


### PR DESCRIPTION
Missing from commit 1006095.