### PR TITLE
chore: Revert "enable xz compression for the workspace"

### DIFF
--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -13,7 +13,6 @@
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually
     - service sysstat start && sar -P ALL 2 -o /var/log/sysstat/sysstat.log -uqrbS >/dev/null 2>&1 &
-    - apt update && apt install -yyq xz-utils
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
     # Export required yocto-build script variables
@@ -33,12 +32,11 @@
     - mount.nfs4 ${SSTATE_CACHE_INTRNL_ADDR}:/sstate-cache /mnt/sstate-cache
     # Traps only work if executed in a sub shell.
     - "("
-    - mv workspace.tar.xz stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
 
     - function handle_exit() {

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -23,19 +23,18 @@ build:client:docker:
     # Default value, will later be overwritten if successful
     - echo "failure" > /JOB_RESULT.txt
     # Dependencies
-    - apk --update add python3 py-pip curl jq bash git xz
+    - apk --update add python3 py-pip curl jq bash git
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install --break-system-packages -r requirements.txt
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
     # Prepare workspace
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz /tmp
+    - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
   script:
     - echo ${CI_REGISTRY_PASSWORD} | docker login --username ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     # First build mender's repo Docker image
@@ -78,14 +77,12 @@ build:mender-cli:
     - echo "failure" > /JOB_RESULT.txt
 
     # Restore workspace from init stage
-    - apk --update add xz
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz /tmp
+    - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     # Export GOPATH
     - export GOPATH="$WORKSPACE/go"
 
@@ -141,15 +138,14 @@ build:mender-artifact:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk --update add bash curl git make jq xz
+    - apk --update add bash curl git make jq
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz /tmp
+    - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
 
     # Post job status
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
@@ -226,12 +222,11 @@ build:mender-gateway:docker:
     - pip3 install --break-system-packages -r requirements.txt
     # Prepare workspace
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz /tmp
+    - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
   script:
     - docker_url=$($WORKSPACE/integration/extra/release_tool.py --map-name docker mender-gateway docker_url)
     - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-gateway
@@ -258,16 +253,14 @@ build:mender-gateway:package:
   allow_failure: false
   before_script:
     # Early exit when building an integration version without mender-gateway
-    - apt update && apt install -yyq xz-utils
-    - xz -d workspace.tar.xz
-    - tar -tf workspace.tar
+    - tar -tf workspace.tar.gz
         ./go/src/github.com/mendersoftware/mender-gateway  >/dev/null 2>/dev/null || exit 0
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar /tmp
+    - mv workspace.tar.gz /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     # Move into component path
     - cd ${WORKSPACE}/go/src/github.com/mendersoftware/mender-gateway

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -17,7 +17,7 @@ init:workspace:
       trap handle_exit EXIT
 
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk --update add git openssh bash python3 curl py3-pip jq xz
+    - apk --update add git openssh bash python3 curl py3-pip jq
 
     # release_tool.py dependencies
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
@@ -160,9 +160,8 @@ init:workspace:
     - cat ${CI_PROJECT_DIR}/build_revisions.env
 
     # Save artifact the rest of the pipeline
-    - tar -cf /tmp/workspace.tar .
-    - xz -${WORKSPACE_XZ_LEVEL:-1} ${WORKSPACE_XZ_ARGS} /tmp/workspace.tar
-    - mv /tmp/workspace.tar.xz ${CI_PROJECT_DIR}/workspace.tar.xz
+    - tar -czf /tmp/workspace.tar.gz .
+    - mv /tmp/workspace.tar.gz ${CI_PROJECT_DIR}/workspace.tar.gz
 
     # Always keep this at the end of the script stage
     - echo "success" > /JOB_RESULT.txt
@@ -176,7 +175,7 @@ init:workspace:
   artifacts:
     expire_in: 2w
     paths:
-      - workspace.tar.xz
+      - workspace.tar.gz
     reports:
       dotenv:
         - build_revisions.env

--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -38,10 +38,9 @@ mender-qa:failure:
   dependencies:
     - init:workspace
   before_script:
-    - apk --update add git xz
+    - apk --update add git
     # Get mender source
-    - xz -d ${CI_PROJECT_DIR}/workspace.tar.xz
-    - tar xf ${CI_PROJECT_DIR}/workspace.tar ./go/src/github.com/mendersoftware/${REPO_NAME}
+    - tar xf ${CI_PROJECT_DIR}/workspace.tar.gz ./go/src/github.com/mendersoftware/${REPO_NAME}
     - mv go/src/github.com/mendersoftware/${REPO_NAME} ${CI_PROJECT_DIR}/${REPO_NAME}
     - cd ${CI_PROJECT_DIR}/${REPO_NAME}
   script:

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -7,17 +7,16 @@
   image: debian:buster
   before_script:
     # Install dependencies
-    - apt update && apt install -yyq awscli git wget python3 python3-pip xz-utils
+    - apt update && apt install -yyq awscli git wget python3 python3-pip
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
   script:
     # Publish boards artifacts and sdimg (when not qemu board).
@@ -268,17 +267,16 @@ release_board_artifacts:raspberrypi4:automatic:
   before_script:
     - *publish_helper_functions
     # Install dependencies
-    - apt update && apt install -yyq awscli git wget python3 python3-pip xz-utils
+    - apt update && apt install -yyq awscli git wget python3 python3-pip
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
   script:
     # mender-cli
@@ -371,17 +369,16 @@ release_binary_tools:automatic:
     - build:mender-monitor:package
   before_script:
     # Install dependencies
-    - apt update && apt install -yyq awscli git wget python3 python3-pip xz-utils
+    - apt update && apt install -yyq awscli git wget python3 python3-pip
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
   script:
     - mender_monitor_version=$($WORKSPACE/integration/extra/release_tool.py --version-of monitor-client --in-integration-version $INTEGRATION_REV)
@@ -413,9 +410,7 @@ release_mender-monitor:automatic:
     - build:mender-gateway:package
   before_script:
     # Early exit when building an integration version without mender-gateway
-    - apt update && apt install -yyq xz-utils
-    - xz -d workspace.tar.xz
-    - tar -tf workspace.tar
+    - tar -tf workspace.tar.gz
         ./go/src/github.com/mendersoftware/mender-gateway  >/dev/null 2>/dev/null || exit 0
     # Install dependencies
     - apt update && apt install -yyq awscli git wget python3 python3-pip
@@ -423,11 +418,11 @@ release_mender-monitor:automatic:
     - pip3 install -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
   script:
     - mender_gateway_version=$($WORKSPACE/integration/extra/release_tool.py --version-of mender-gateway --in-integration-version $INTEGRATION_REV)
@@ -461,17 +456,17 @@ release_mender-gateway:automatic:
     # Check correct dind setup
     - docker version
     # Install dependencies
-    - apk --update add git python3 py3-pip xz
+    - apk --update add git python3 py3-pip
     - wget https://raw.githubusercontent.com/mendersoftware/integration/master/extra/requirements.txt
     - pip3 install --break-system-packages -r requirements.txt
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - mv workspace.tar.xz /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
+    - mv /tmp/stage-artifacts .
     # Login for private repos
     - docker login -u menderbuildsystem -p ${DOCKER_HUB_PASSWORD}
     - docker login -u ntadm_menderci -p ${REGISTRY_MENDER_IO_PASSWORD} registry.mender.io

--- a/gitlab-pipeline/stage/test.yml
+++ b/gitlab-pipeline/stage/test.yml
@@ -33,13 +33,11 @@
 
     # Restore workspace from init stage
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - apk add xz
-    - mv workspace.tar.xz stage-artifacts /tmp
+    - mv workspace.tar.gz stage-artifacts /tmp
     - rm -rf ${WORKSPACE}
     - mkdir -p ${WORKSPACE}
     - cd ${WORKSPACE}
-    - xz -d /tmp/workspace.tar.xz
-    - tar -xf /tmp/workspace.tar
+    - tar -xf /tmp/workspace.tar.gz
     - mv /tmp/stage-artifacts .
 
     # Dependencies for post job status and io stats


### PR DESCRIPTION
Now that we don't have all the backend repositories, we can revert to a faster compression.

It cuts down the init job from 5 to 3 minutes, and presumably will also cut down the time in every other job that decompresses the workspace.

This reverts commit 717d4c60bbc4635dff11e51f0ba8d4c3544a5c16.