### PR TITLE
ci: Switch workspace artifact compression to level preset 0

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -161,7 +161,7 @@ init:workspace:
 
     # Save artifact the rest of the pipeline
     - tar -cf /tmp/workspace.tar .
-    - xz -${WORKSPACE_XZ_LEVEL:-1} ${WORKSPACE_XZ_ARGS} /tmp/workspace.tar
+    - xz -${WORKSPACE_XZ_LEVEL:-0} ${WORKSPACE_XZ_ARGS} /tmp/workspace.tar
     - mv /tmp/workspace.tar.xz ${CI_PROJECT_DIR}/workspace.tar.xz
 
     # Always keep this at the end of the script stage


### PR DESCRIPTION
Now that we don't have all the backend repositories, we can use a faster compression level by default.

It cuts down the init job from 5 to 3 minutes, and presumably will also cut down the time in every other job that decompresses the workspace.