### PR TITLE
docs: docker hub secret on hetzner

### DIFF
--- a/Documentation/hetzner-cicd.md
+++ b/Documentation/hetzner-cicd.md
@@ -41,3 +41,10 @@ in Hetzner hosts, both bare-metal and VMs.
   pass show mender/cicd/hetznercloud/ssh_key-01-priv.pem | ssh-add - \
   ssh -J root@49.13.211.148 root@192.168.84.3
   ```
+
+## Secrets
+
+The Hetzener hosts are using the Docker Hub user `northerntechreadonly` to pull
+the images. The password is stored in the `mender/cicd/docker.com/northerntechreadonly`
+mystiko entry.
+


### PR DESCRIPTION
Hetzner hosts are using a specific Docker hub user to pull images without triggering the rate limit issue. This was missing in the documentation.

Ticket: SEC-1451
Changelog: None