### PR TITLE
QA-636: Remove obsolete coverage finish build jobs

### DIFF
--- a/gitlab-pipeline/stage/post.yml
+++ b/gitlab-pipeline/stage/post.yml
@@ -25,55 +25,6 @@ mender-qa:failure:
   script:
     - $CI_PROJECT_DIR/scripts/github_pull_request_status failure "mender-qa pipeline failed" $CI_PIPELINE_URL ci/mender-qa
 
-
-.coveralls:finish-build:
-  tags:
-    - hetzner-amd-beefy
-  stage: .post
-  dependencies: []
-  # See https://docs.coveralls.io/parallel-build-webhook
-  variables:
-    COVERALLS_WEBHOOK_URL: "https://coveralls.io/webhook"
-  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/alpine/curl
-  dependencies:
-    - init:workspace
-  before_script:
-    - apk --update add git xz
-    # Get mender source
-    - xz -d ${CI_PROJECT_DIR}/workspace.tar.xz
-    - tar xf ${CI_PROJECT_DIR}/workspace.tar ./go/src/github.com/mendersoftware/${REPO_NAME}
-    - mv go/src/github.com/mendersoftware/${REPO_NAME} ${CI_PROJECT_DIR}/${REPO_NAME}
-    - cd ${CI_PROJECT_DIR}/${REPO_NAME}
-  script:
-    # Mark coverage report as done (mender-client).
-    - 'curl -f ${COVERALLS_WEBHOOK_URL}?repo_token=${COVERALLS_TOKEN} -d "payload[build_num]=$(git rev-parse HEAD)&payload[status]=done"'
-
-# Publish acceptance test coverage into coveralls when either:
-# * running tests for a mender PR: MENDER_REV ~= /pull/XXX/head/
-# * running nightly build: $NIGHTLY_BUILD == "true"
-coverage:finish-build:mender-client:
-  extends: .coveralls:finish-build
-  only:
-    variables:
-      - $MENDER_REV =~ /pull\/.*\/head/
-      - $NIGHTLY_BUILD == "true"
-  variables:
-      COVERALLS_TOKEN: ${MENDER_COVERALLS_TOKEN}
-      REPO_NAME: "mender"
-
-# Publish acceptance test coverage into coveralls when either:
-# * running tests for a mender PR: MENDER_ARTIFACT_REV ~= /pull/XXX/head/
-# * running nightly build: $NIGHTLY_BUILD == "true"
-coverage:finish-build:mender-artifact:
-  extends: .coveralls:finish-build
-  only:
-    variables:
-      - $MENDER_ARTIFACT_REV =~ /pull\/.*\/head/
-      - $NIGHTLY_BUILD == "true"
-  variables:
-      COVERALLS_TOKEN: ${MENDER_ARTIFACT_COVERALLS_TOKEN}
-      REPO_NAME: "mender-artifact"
-
 trigger:mantra:
   stage: .post
   inherit:


### PR DESCRIPTION
The test coverage from client acceptance tests is no longer gathered and submitted.

It went missing from commit 281d75023291a142bc34b6efe2ab31763f63110a.