### PR TITLE
ci: Provide fallback mender-gateway tag for unset MENDER_GATEWAY_REV

### DIFF
--- a/gitlab-pipeline/stage/trigger-integration.yml
+++ b/gitlab-pipeline/stage/trigger-integration.yml
@@ -1,7 +1,8 @@
 .template:trigger:integration-tests:
   stage: trigger:integration
   inherit:
-    variables: false
+    variables:
+      - MENDER_GATEWAY_REV
   variables:
     MENDER_CLIENT_REGISTRY: registry.gitlab.com
     MENDER_CLIENT_ENTERPRISE_REGISTRY: registry.gitlab.com


### PR DESCRIPTION
If MENDER_GATEWAY_REV is unset, the pipeline `test_mtls` are guaranteed to fail. Using `master` as a fallback value.