### PR TITLE
docs: added zephyr hetzner vm references

### DIFF
--- a/Documentation/hetzner-cicd.md
+++ b/Documentation/hetzner-cicd.md
@@ -42,6 +42,10 @@ in Hetzner hosts, both bare-metal and VMs.
   ssh -J root@49.13.211.148 root@192.168.84.3
   ```
 
+### Hetzner VM for Zephyr testing
+* [Internal documentation](https://github.com/NorthernTechHQ/sre-iac/tree/main/hetzner-zephyr-qa)
+
+
 ## Secrets
 
 The Hetzener hosts are using the Docker Hub user `northerntechreadonly` to pull


### PR DESCRIPTION
References for the zephyr hetzner Gitlab Runner VM for the IaC repository which describes this instance

Ticket: QA-913