### PR TITLE
MEN-8159: Parametrize triggering the integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -178,6 +178,10 @@ variables:
     value: "false"
     description: |-
       Flag to run tests in child pipeline mender-convert
+  RUN_INTEGRATION_TESTS:
+    value: "true"
+    description: |-
+      Flag to run tests trigger child pipeline for integration tests
 
   # Publication
   PUBLISH_DOCKER_CLIENT_IMAGES:

--- a/gitlab-pipeline/stage/trigger-integration.yml
+++ b/gitlab-pipeline/stage/trigger-integration.yml
@@ -35,6 +35,8 @@
 
 trigger:generate-gitlab-integration-rev:
   stage: trigger:integration
+  rules:
+    - if: $RUN_INTEGRATION_TESTS == "true"
   script:
   # Convert INTEGRATION_REV on format `pull/0000/head` to `pr_0000` to specify which gitlab branch to trigger
   - |
@@ -49,6 +51,8 @@ trigger:generate-gitlab-integration-rev:
 
 trigger:integration-tests:
   extends: .template:trigger:integration-tests
+  rules:
+    - if: $RUN_INTEGRATION_TESTS == "true"
   needs:
     - trigger:generate-gitlab-integration-rev
     - build:client:qemu


### PR DESCRIPTION
In the context of the Client releases we want to let the release coordinator decide when to trigger client acceptance tests, integration tests, both, or none.

The default does not change.