### PR TITLE
ci: Remove dependencies for generation CI job

### DIFF
--- a/gitlab-pipeline/stage/trigger-integration.yml
+++ b/gitlab-pipeline/stage/trigger-integration.yml
@@ -37,6 +37,7 @@ trigger:generate-gitlab-integration-rev:
   stage: trigger:integration
   rules:
     - if: $RUN_INTEGRATION_TESTS == "true"
+  needs: []
   script:
   # Convert INTEGRATION_REV on format `pull/0000/head` to `pr_0000` to specify which gitlab branch to trigger
   - |


### PR DESCRIPTION
This job has no real dependencies. The actual trigger depends both on the generation and the QEMU build, so by setting up no dependencies in the generation in effect we can start the integration tests in parallel of the client acceptance tests (as it used to be in the old times).