### PR TITLE
Add a possibility to send results to Mantra from parallel test runs.

### DIFF
--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -2,7 +2,7 @@
 build:client:qemu:
   only:
     variables:
-      - $BUILD_CLIENT == "true"``
+      - $BUILD_CLIENT == "true"
   stage: yocto:build-n-test
   extends: .template_build_test_acc
   services:
@@ -78,7 +78,7 @@ test:acceptance:qemux86_64:uefi_grub:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_qemux86_64_uefi_grub
+        client_accep_qemux86_64_uefi_grub
         $build_name
         results_accep_qemux86_64_uefi_grub.xml || true
 
@@ -130,7 +130,7 @@ test:acceptance:qemux86_64:uefi_grub:cross-platform:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_qemux86_64_uefi_grub_cross_platform
+        client_accep_cross_platform
         $build_name
         results_accep_qemux86_64_uefi_grub_cross_platform.xml || true
 
@@ -183,7 +183,7 @@ test:acceptance:vexpress_qemu:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_vexpress_qemu
+        client_accep_vexpress_qemu
         $build_name
         results_accep_vexpress_qemu.xml || true
 
@@ -236,7 +236,7 @@ test:acceptance:qemux86_64:bios_grub:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_qemux86_64_bios_grub
+        client_accep_qemux86_64_bios_grub
         $build_name
         results_accep_qemux86_64_bios_grub.xml || true
 
@@ -289,7 +289,7 @@ test:acceptance:qemux86_64:bios_grub_gpt:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_qemux86_64_bios_grub_gpt
+        client_accep_qemux86_64_bios_grub_gpt
         $build_name
         results_accep_qemux86_64_bios_grub_gpt.xml || true
 
@@ -342,7 +342,7 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_vexpress_qemu_uboot_uefi_grub
+        client_accep_vexpress_qemu_uboot_uefi_grub
         $build_name
         results_accep_vexpress_qemu_uboot_uefi_grub.xml || true
 
@@ -398,7 +398,7 @@ test:acceptance:vexpress_qemu:flash:
     -   build_name=pullreq-$(date +%Y-%m-%d)-${CI_PIPELINE_ID}
     - fi
     - ${CI_PROJECT_DIR}/scripts/mantra_post_test_results
-        accep_vexpress_qemu_flash
+        client_accep_vexpress_qemu_flash
         $build_name
         results_accep_vexpress_qemu_flash.xml || true
 

--- a/scripts/mantra_post_test_results
+++ b/scripts/mantra_post_test_results
@@ -5,21 +5,26 @@ set -x
 
 usage() {
     echo "Usage:"
+    echo "Usage:"
     echo "  $0 --ensure <project-key> <build-name> <xml-file>"
-    echo "  $0          <project-key> <build-name> <xml-file>"
+    echo "        Look up the build; if it does not exist, create it, then"
+    echo "        append <xml-file> test results to that build’s results."
+    echo
+    echo "  $0 <project-key> <build-name> <xml-file>"
+    echo "        Always create a *new* build named <build-name> and upload"
+    echo "        <xml-file> test results to it."
     echo
     echo "Project keys:"
-    echo "  accep_qemux86_64_uefi_grub"
-    echo "  accep_vexpress_qemu"
-    echo "  accep_qemux86_64_bios_grub"
-    echo "  accep_qemux86_64_bios_grub_gpt"
-    echo "  accep_vexpress_qemu_uboot_uefi_grub"
-    echo "  accep_vexpress_qemu_flash"
+    echo "  client_accep_qemux86_64_uefi_grub"
+    echo "  client_accep_vexpress_qemu"
+    echo "  client_accep_qemux86_64_bios_grub"
+    echo "  client_accep_qemux86_64_bios_grub_gpt"
+    echo "  client_accep_vexpress_qemu_uboot_uefi_grub"
+    echo "  client_accep_vexpress_qemu_flash"
     echo "  backend_integration_open_source"
     echo "  backend_integration_enterprise"
     echo "  full_integration"
-    echo "  full_integration_enterprise"
-    echo "  accep_qemux86_64_uefi_grub_cross_platform"
+    echo "  client_accep_cross_platform"
     exit 1
 }
 
@@ -36,18 +41,19 @@ project_key=$1 ; shift  # human readable project name
 build_name=$1  ; shift  # human-readable name (nightly-YYYY-MM-DD or pullreq-…)
 results_file=$1         # JUnit XML to upload
 
+# please note that there might be some gaps in the project_id numbers; this is related to some projects not being
+# used anymore but still results might be stored in Mantra. The important part is that the project_id numbers are unique.
 case "$project_key" in
-    accep_qemux86_64_uefi_grub)                project_id=1  ;;
-    accep_vexpress_qemu)                       project_id=2  ;;
-    accep_qemux86_64_bios_grub)                project_id=3  ;;
-    accep_qemux86_64_bios_grub_gpt)            project_id=4  ;;
-    accep_vexpress_qemu_uboot_uefi_grub)       project_id=5  ;;
-    accep_vexpress_qemu_flash)                 project_id=6  ;;
-    backend_integration_open_source)           project_id=7  ;;
-    backend_integration_enterprise)            project_id=8  ;;
-    full_integration)                          project_id=9  ;;
-    full_integration_enterprise)               project_id=10 ;;
-    accep_qemux86_64_uefi_grub_cross_platform) project_id=11 ;;
+    client_accep_qemux86_64_uefi_grub)          project_id=1  ;;
+    client_accep_vexpress_qemu)                 project_id=2  ;;
+    client_accep_qemux86_64_bios_grub)          project_id=3  ;;
+    client_accep_qemux86_64_bios_grub_gpt)      project_id=4  ;;
+    client_accep_vexpress_qemu_uboot_uefi_grub) project_id=5  ;;
+    client_accep_vexpress_qemu_flash)           project_id=6  ;;
+    backend_integration_open_source)            project_id=7  ;;
+    backend_integration_enterprise)             project_id=8  ;;
+    full_integration)                           project_id=9  ;;
+    client_accep_cross_platform)                project_id=11 ;;
     *)  echo "FATAL: unknown Mantra project key '$project_key'" >&2; exit 2 ;;
 esac
 


### PR DESCRIPTION
Extend `mantra_post_test_results` to be able to send tests results from parallel test executions with multiple shards.