### PR TITLE
docs: new gitlab runners

### DIFF
--- a/Documentation/hetzner-cicd.md
+++ b/Documentation/hetzner-cicd.md
@@ -10,6 +10,7 @@ in Hetzner hosts, both bare-metal and VMs.
     - [Hetzner CAX21](#hetzner-cax21)
     - [Hetzner VM Podman cpx31 gitlab-runner-podman-01](#hetzner-vm-podman-cpx31-gitlab-runner-podman-01)
     - [Hetzner VM for Zephyr testing](#hetzner-vm-for-zephyr-testing)
+    - [Hetzner AX42](#hetzner-ax42)
   - [Secrets](#secrets)
 
 
@@ -58,6 +59,16 @@ in Hetzner hosts, both bare-metal and VMs.
 
 ### Hetzner VM for Zephyr testing
 * [Internal documentation](https://github.com/NorthernTechHQ/sre-iac/tree/main/hetzner-zephyr-qa)
+
+
+### Hetzner AX42
+* Node type: bare-metal
+* IP: `5.9.120.171`
+* Connection string:
+  ```bash
+  eval `ssh-agent` && \
+  pass show mender/cicd/hetznercloud/gitlab-hetzner-ax41-runner-ssh_key-priv.pem | ssh-add - && ssh root@5.9.120.171
+  ```
 
 
 ## Secrets

--- a/Documentation/mender-ci-cd.md
+++ b/Documentation/mender-ci-cd.md
@@ -302,7 +302,10 @@ of truth.
 | hetzner-amd-beefy            | Hetzner EX130-R      | hetzner-amd-beefy                                                                                           | false      |
 | hetzner-amd-beefy-privileged | Hetzner AX41-NVMe    | hetzner-amd-beefy-privileged                                                                                | true       |
 | hetzner-arm                  | Hetzner CAX21        | hetzner-arm                                                                                                 | false      |
-| hetzner-podman               | Hetzner CPX31        | hetzner-amd                                                                                                 | false      |
+| hetzner-podman               | Hetzner CPX31        | hetzner-podman                                                                                              | false      |
+| hetzner-podman-ax42          | Hetzner AX42         | hetzner-podman-ax42                                                                                         | false      |
+| hetzner-amd-ax42             | Hetzner AX42         | hetzner-amd-ax42                                                                                            | false      |
+| k8s                          | AWS c7i.2xlarge      | k8s                                                                                                         | false      |
 
 
 ## Installing systemd services and timers


### PR DESCRIPTION
Documenting new Gitlab Runners: Hetzner AX42 and K8s runner

Ticket: QA-1010
Changelog: None