### PR TITLE
ci: only run client release jobs when BUILD_CLIENT is true 

### DIFF
--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -184,7 +184,9 @@ release:virtual-client:manual:
     - init:workspace
     - build:client:qemu
     - build:client:docker
-  when: manual
+  rules:
+    - if: $BUILD_CLIENT == "true"
+      when: manual
   extends: .template_release_docker_images:client-only
 
 # This job allows mender repo to publish the related Docker client images on
@@ -195,7 +197,6 @@ release:virtual-client:automatic:
     - build:client:qemu
     - build:client:docker
     - trigger:integration-tests
-  only:
-    variables:
-      - $PUBLISH_DOCKER_CLIENT_IMAGES == "true"
+  rules:
+    - if: $PUBLISH_DOCKER_CLIENT_IMAGES == "true" && $BUILD_CLIENT == "true"
   extends: .template_release_docker_images:client-only


### PR DESCRIPTION
This allows us to run pipelines with `BUILD_CLIENT: false`