### PR TITLE
fix: Pass `$MENDER_FLASH_REV` to `docker build client-docker-addons`

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -49,6 +49,7 @@ build:client:docker:
     - cd $WORKSPACE/integration/extra/mender-client-docker-addons
     - docker build
       --build-arg MENDER_CLIENT_REV=$MENDER_REV
+      --build-arg MENDER_FLASH_REV=$MENDER_FLASH_REV
       --build-arg MENDER_CONNECT_REV=$MENDER_CONNECT_REV
       --build-arg MENDER_SETUP_REV=$MENDER_SETUP_REV
       --tag ${GITLAB_REGISTRY_PREFIX}-mender-client-docker-addons


### PR DESCRIPTION
So that it builds the desired revision and not `master` (default).

Ticket: QA-993
Changelog: none