### PR TITLE
fix: Revert "fix: Pass `$MENDER_FLASH_REV` to `docker build client-do…

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -49,7 +49,6 @@ build:client:docker:
     - cd $WORKSPACE/integration/extra/mender-client-docker-addons
     - docker build
       --build-arg MENDER_CLIENT_REV=$MENDER_REV
-      --build-arg MENDER_FLASH_REV=$MENDER_FLASH_REV
       --build-arg MENDER_CONNECT_REV=$MENDER_CONNECT_REV
       --build-arg MENDER_SETUP_REV=$MENDER_SETUP_REV
       --tag ${GITLAB_REGISTRY_PREFIX}-mender-client-docker-addons


### PR DESCRIPTION
…cker-addons`"

This reverts commit
465a8846698e0734e4c3feb54a67915741978991. `mender-flash` is not needed in the client container as it never performs a rootfs-image update.

Ticket: QA-993
Changelog: none