### PR TITLE
ci: define `when: manual` outside of rules

### DIFF
--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -186,7 +186,7 @@ release:virtual-client:manual:
     - build:client:docker
   rules:
     - if: $BUILD_CLIENT == "true"
-      when: manual
+  when: manual
   extends: .template_release_docker_images:client-only
 
 # This job allows mender repo to publish the related Docker client images on


### PR DESCRIPTION
Align it with the other release jobs.
This allows the jobs in .post to run even though
`release:virtual-client:manual` isn't run