### PR TITLE
feat: keep qemu build artifacts and archive them in ci

### DIFF
--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -59,6 +59,8 @@ test:acceptance:qemux86_64:uefi_grub:
     - cd ${CI_PROJECT_DIR}
     - mkdir -p stage-artifacts
     - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
+    # Compress and archive QEMU build images and other related artifacts
+    - tar -czf qemu-artifacts.tar.gz --strip-components=2 $WORKSPACE/qemux86-64-uefi-grub/{*.uefiimg,*.sdimg,*.wic,ovmf.qcow2,bzImage} || true
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
     - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
@@ -90,6 +92,7 @@ test:acceptance:qemux86_64:uefi_grub:
     when: always
     paths:
       - stage-artifacts/
+      - qemu-artifacts.tar.gz
       - results_accep_qemux86_64_uefi_grub.xml
       - report_accep_qemux86_64_uefi_grub.html
       - acceptance-tests-coverage


### PR DESCRIPTION
Attempt at copying over as many QEMU images and other related items to the workspace, and then archiving these files in the CI.

I did it for the `test:acceptance:qemux86_64:uefi_grub` for starters, but if it works, we can expand that to other board types.

My one concern is that this can potentially be a lot of data to keep accumulating and archived for 2 weeks (the lifetime for CI artifacts we have set) Maybe this should be optional? My another concern is, if this is actually useful...