### PR TITLE
ci: checkout mender-gateway in init:workspace

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -134,6 +134,9 @@ init:workspace:
           $(repo_to_rev $repo)
     - done
 
+    # Add mender-gateway
+    - checkout_repo git@github.com:mendersoftware/mender-gateway go/src/github.com/mendersoftware/mender-gateway $MENDER_GATEWAY_REV
+
     # Add other repositories.
     - checkout_repo git@github.com:openembedded/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV
     - if [ "$BUILD_RASPBERRYPI3" = true ] || [ "$BUILD_RASPBERRYPI4" = true ]; then


### PR DESCRIPTION
When we marked mender-gateway as non-releasable in the release_tool, mender-gateway was removed from the release_tool's client repositories list, which resulted in mender-gateway not being checked out and that created errors like: `ERROR: mender-gateway-2.0.0-r0 do_version_check: No mender-gateway binary found.`