### PR TITLE
docs: add more pipelines to qa duty

### DIFF
--- a/Documentation/qa-duty.md
+++ b/Documentation/qa-duty.md
@@ -37,13 +37,22 @@ The general advise is to do a short investigation before asking for help from
 others in the team. For obvious test infra errors we can just re-run the jobs;
 for actual test failures we need to asses if it might be a regression or not.
 
+### Nightly Mender Server
+
+Link: https://gitlab.com/Northern.tech/Mender/mender-server/-/pipelines?page=1&scope=all&source=schedule
+Link: https://gitlab.com/Northern.tech/Mender/mender-server-enterprise/-/pipelines?page=1&scope=all&source=schedule
+
+Nightly tests over the mender-server monorepo. These include the whole spectrum from unit tests to E2E tests.
+
+The second pipeline is for the Enterprise version but essentially features the same jobs.
+
 ### Nightly Mender Server Integration tests
 
 Link: *qastatus link pending*
 Link: https://gitlab.com/Northern.tech/Mender/integration/-/pipeline_schedules
 Link: https://gitlab.com/Northern.tech/Mender/integration/-/pipelines?page=1&scope=all&source=schedule
- 
-These tests are related to the Mender Server monorepo artifacts from `main`, 
+
+These tests are related to the Mender Server monorepo artifacts from `main`,
 tesing it over the current Mender client artifacts `master`.
 
 There is no golden rule on what to do when the "Last Pipeline" in the link above
@@ -52,6 +61,12 @@ is not green.
 The general advise is to do a short investigation before asking for help from
 others in the team. For obvious test infra errors we can just re-run the jobs;
 for actual test failures we need to asses if it might be a regression or not.
+
+### Nightly Mender Gateway
+
+Link: https://gitlab.com/Northern.tech/Mender/mender-gateway/-/pipelines?page=1&scope=all&source=schedule
+
+Nightly pipelines for `mender-gateway`. There are two branches to check: `master` and `2.0.x`
 
 ### Weekly Mender integration tests on staging
 
@@ -64,11 +79,19 @@ On Tuesday morning, the person on QA duty must check the status of the pipeline 
 do a short investigation before asking for help from others in the team in
 case of failures.
 
+### Other notable weekly pipelines
+
+Link: https://gitlab.com/Northern.tech/Mender/integration-test-runner/-/pipeline_schedules
+Link: https://gitlab.com/Northern.tech/Mender/mender-mcu/-/pipeline_schedules
+Link: https://gitlab.com/Northern.tech/Mender/monitor-client/-/pipeline_schedules
+
 ### Individual pipelines
 
 Link: https://qastatus.mender.io/build-status
 
 All should be green. If a pipeline is broken, ping the corresponding team.
+
+Note that `integration staging` is currently broken, you can skip that one.
 
 They get build after every merge to master on the corresponding repository, and
 on weekly basis every Tuesday evening, at 9 PM UTC.


### PR DESCRIPTION
- described more pipelines that we look at on QA duty
- added a note about staging which can be skipped