### PR TITLE
ci: download mender-orchestrator master tarball

### DIFF
--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -282,6 +282,16 @@ SRC_URI:pn-mender-gateway:append = " file:///$WORKSPACE/downloads/mender-gateway
 EOF
     fi
 
+    # For now the mender-orchestrator version is hardcoded to master as we don't yet
+    # have the logic to checkout revisions and build from source.
+    # This will be aligned with the other closed-source components in QA-1180
+    local version="master"
+    s3cmd get s3://${S3_BUCKET_NAME}/mender-orchestrator/${version}/mender-orchestrator-${version}.tar.xz $WORKSPACE/downloads
+    cat >> $BUILDDIR/conf/local.conf <<EOF
+PREFERRED_VERSION:pn-mender-orchestrator = "$version"
+SRC_URI:pn-mender-orchestrator = "file:///$WORKSPACE/downloads/mender-orchestrator-${version}.tar.xz"
+EOF
+
     cat >> $BUILDDIR/conf/local.conf <<EOF
 # When using externalsrc from CI, we still want to apply patches
 SRCTREECOVEREDTASKS:remove = "do_patch"


### PR DESCRIPTION
This is the missing piece of for test_mender_orchestrator to run. Since this is a closed-source component, we need to download and add the tarball.

For now we hardcode the version to `master` (see comment in yocto-build-and-test.sh). The plan is to align this with the other closed-source components (e.g. mender-gateway) in QA-1180