### PR TITLE
Prevent timeouts during file sync & improve CI performance

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -94,7 +94,7 @@ echo "IP information:"
 /sbin/ip addr || true
 
 
-RSYNC="rsync --delete -czrlpt -T /tmp"
+RSYNC="rsync --delete -zrlpt -T /tmp"
 RSH="ssh -o BatchMode=yes"
 
 # Support launching scripts that were initially launched under bash.


### PR DESCRIPTION
Removed -c flag from rsync command which is likely causing timeouts by
computing checksums for all files. Default size/mtime comparison is
sufficient for the CI workspace synchronization and significantly
faster.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
