### PR TITLE
sync only output directory to reduce CI transfer time

### DIFF
--- a/scripts/initialize-build-host.sh
+++ b/scripts/initialize-build-host.sh
@@ -398,7 +398,7 @@ then
     # Copy the workspace back after job has ended.
     if [ -n "$WORKSPACE" ]
     then
-        $RSYNC -e "$RSH"    $login:"$WORKSPACE_REMOTE"/  "$WORKSPACE"/
+        $RSYNC -e "$RSH"    $login:"$WORKSPACE_REMOTE"/output/  "$WORKSPACE"/
     fi
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
Change rsync to sync only the `output/` directory instead of the entire
workspace, avoiding transfer of thousands of unnecessary files in other
directories like cfengine, masterfiles, etc.

Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
