### PR TITLE
chore: run PR pipelines on pull/NNN/merge revisions

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -101,7 +101,7 @@ init:workspace:
 
     # Add MENDER_QA_REV, which is special, since it is this repository.
     - if echo "$CI_COMMIT_REF_NAME" | egrep '^pr_[0-9]+$'; then
-        export MENDER_QA_REV="pull/$(echo "$CI_COMMIT_REF_NAME" | egrep -o '[0-9]+')/head";
+        export MENDER_QA_REV="pull/$(echo "$CI_COMMIT_REF_NAME" | egrep -o '[0-9]+')/merge";
       else
         export MENDER_QA_REV="$CI_COMMIT_REF_NAME";
       fi

--- a/gitlab-pipeline/stage/trigger-integration.yml
+++ b/gitlab-pipeline/stage/trigger-integration.yml
@@ -45,7 +45,7 @@ trigger:generate-gitlab-integration-rev:
   # Convert INTEGRATION_REV on format `pull/0000/head` to `pr_0000` to specify which gitlab branch to trigger
   - |
     GITLAB_INTEGRATION_REV=$INTEGRATION_REV
-    if [[ "$INTEGRATION_REV" =~ ^pull/([0-9]+)/head$ ]]; then
+    if [[ "$INTEGRATION_REV" =~ ^pull/([0-9]+)/(head|merge)$ ]]; then
       GITLAB_INTEGRATION_REV="pr_${BASH_REMATCH[1]}"
     fi
   - echo "GITLAB_INTEGRATION_REV=$GITLAB_INTEGRATION_REV" >> gitlab_integration_rev.env

--- a/scripts/github_pull_request_status
+++ b/scripts/github_pull_request_status
@@ -15,7 +15,7 @@ EOF
 # branch. It is recorded in the "CI_*" variables though.
 if [ "$CI_PROJECT_NAME" = "mender-qa" ]; then
     if echo "$CI_COMMIT_REF_NAME" | egrep '^pr_[0-9]+$'; then
-        export MENDER_QA_REV="pull/$(echo "$CI_COMMIT_REF_NAME" | egrep -o '[0-9]+')/head"
+        export MENDER_QA_REV="pull/$(echo "$CI_COMMIT_REF_NAME" | egrep -o '[0-9]+')/merge"
     else
         export MENDER_QA_REV="$CI_COMMIT_REF_NAME"
     fi
@@ -33,7 +33,7 @@ for key in $(env | sed -e 's/=.*//'); do
         # Skip GitLab/Docker duplicated environment vars, i.e. MENDER_REV has a DOCKER_ENV_MENDER_REV
         continue
     fi
-    if ! eval echo \$$key | egrep -q "^pull/[0-9]+/head$"; then
+    if ! eval echo \$$key | egrep -q "^pull/[0-9]+/(head|merge)$"; then
         # Not a pull request, skip.
         continue
     fi

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -256,7 +256,7 @@ prepare_build_config() {
         # -> if PR, use master-git%
         # -> otherwise env ver + git% (maser-git, 5.0.x-git, etc)
         local yocto_version="$env_version-git%"
-        if [[ "$env_version" =~ ^pull/[0-9]+/head$ ]]; then
+        if [[ "$env_version" =~ ^pull/[0-9]+/(head|merge)$ ]]; then
             yocto_version="master-git%"
         fi
         local on_exact_tag=$(test "$env_version" != "master" && \
@@ -838,7 +838,7 @@ build_and_test_client() {
 
             # Prepare deliveries: modified fs, release_1 artifact, and compressed sdimg for hw boards
             local client_version="$MENDER_CLIENT_SUBCOMPONENTS_REV"
-            if [[ "$client_version" =~ ^pull/[0-9]+/head$ ]]; then
+            if [[ "$client_version" =~ ^pull/[0-9]+/(head|merge)$ ]]; then
                 client_version="pr"
             fi
             cp $WORKSPACE/$board_name/$image_name-$device_type.ext4 $WORKSPACE/$board_name/$image_name-$device_type-release_1.ext4


### PR DESCRIPTION
Switch MENDER_QA_REV from /head to /merge. Update all regex patterns to accept both /head and /merge for backward compatibility with manual --pr overrides.

No fallback — if the merge ref is unavailable, the pipeline fails. Developers can manually trigger on /head at GitLab.


Ticket: QA-1505