### PR TITLE
chore: replace poky with openembedded-core, meta-yocto and bitbake

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,20 +52,32 @@ variables:
     value: "master"
     description: |-
       Version of meta-mender
-  POKY_REV:
+  YOCTO_REV:
     value: "scarthgap"
     description: |-
-      Version of poky
+      Yocto release branch. Default for openembedded-core, bitbake, meta-yocto.
+  OPENEMBEDDED_CORE_REV:
+    value: ${YOCTO_REV}
+    description: |-
+      Version of openembedded-core
+  BITBAKE_REV:
+    value: ${YOCTO_REV}
+    description: |-
+      Version of bitbake
+  META_YOCTO_REV:
+    value: ${YOCTO_REV}
+    description: |-
+      Version of meta-yocto
   META_OPENEMBEDDED_REV:
-    value: ${POKY_REV}
+    value: ${YOCTO_REV}
     description: |-
       Version of meta-openembedded
   META_VIRTUALIZATION_REV:
-    value: ${POKY_REV}
+    value: ${YOCTO_REV}
     description: |-
       Version of meta-virtualization
   META_RASPBERRYPI_REV:
-    value: ${POKY_REV}
+    value: ${YOCTO_REV}
     description: |-
       Version of meta-raspberrypi. Only applicable for kirkstone or older
 

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -86,18 +86,32 @@ init:workspace:
           echo "$(eval echo \$$(echo $1 | tr [a-z-] [A-Z_])_REV)"
       }
 
-    # Clean WORKSPACE and clone poky in the root
+    # Clean WORKSPACE and clone Yocto core repos
     - find ${WORKSPACE}
       -mindepth 1
       -maxdepth 1
       -not -name $(basename ${CI_PROJECT_DIR})
       -exec rm -rf '{}' ';'
     - cd ${WORKSPACE}
-    - git init . && git remote add origin https://github.com/mendersoftware/poky
-    - git fetch && git checkout -f origin/${POKY_REV}
-    - (
-    -   echo "POKY_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env
-    - )
+
+    # Map Yocto codenames to pinned release tags for the split repos
+    # (openembedded-core, bitbake, meta-yocto). These repos share the
+    # yocto-X.Y.Z tag scheme. Bump the tag here when upgrading.
+    - |
+      yocto_codename_to_tag() {
+        case $1 in
+          scarthgap) echo "yocto-5.0.17" ;;
+          kirkstone) echo "yocto-4.0.34" ;;
+          *) echo "$1" ;;
+        esac
+      }
+    - OPENEMBEDDED_CORE_REV=$(yocto_codename_to_tag "$OPENEMBEDDED_CORE_REV")
+    - BITBAKE_REV=$(yocto_codename_to_tag "$BITBAKE_REV")
+    - META_YOCTO_REV=$(yocto_codename_to_tag "$META_YOCTO_REV")
+
+    - checkout_repo https://git.openembedded.org/openembedded-core openembedded-core $OPENEMBEDDED_CORE_REV
+    - checkout_repo https://git.openembedded.org/bitbake openembedded-core/bitbake $BITBAKE_REV
+    - checkout_repo https://git.yoctoproject.org/meta-yocto meta-yocto $META_YOCTO_REV
 
     # Add MENDER_QA_REV, which is special, since it is this repository.
     - if echo "$CI_COMMIT_REF_NAME" | egrep '^pr_[0-9]+$'; then

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -82,18 +82,31 @@ init:workspace:
           echo "$(eval echo \$$(echo $1 | tr [a-z-] [A-Z_])_REV)"
       }
 
-    # Clean WORKSPACE and clone poky in the root
+    # Clean WORKSPACE and clone Yocto core repos
     - find ${WORKSPACE}
       -mindepth 1
       -maxdepth 1
       -not -name $(basename ${CI_PROJECT_DIR})
       -exec rm -rf '{}' ';'
     - cd ${WORKSPACE}
-    - git init . && git remote add origin https://github.com/mendersoftware/poky
-    - git fetch && git checkout -f origin/${POKY_REV}
-    - (
-    -   echo "POKY_REV_GIT_SHA=$(git rev-parse HEAD)" >> ${CI_PROJECT_DIR}/build_revisions.env
-    - )
+
+    # Map Yocto codenames to pinned release tags for openembedded-core, bitbake and meta-yocto.
+    # These repos share the yocto-X.Y.Z tag scheme. Bump the tag here when upgrading.
+    - |
+      yocto_codename_to_tag() {
+        case $1 in
+          wrynose) echo "yocto-6.0" ;;
+          scarthgap) echo "yocto-5.0.17" ;;
+          *) echo "$1" ;;
+        esac
+      }
+    - OPENEMBEDDED_CORE_REV=$(yocto_codename_to_tag "$OPENEMBEDDED_CORE_REV")
+    - BITBAKE_REV=$(yocto_codename_to_tag "$BITBAKE_REV")
+    - META_YOCTO_REV=$(yocto_codename_to_tag "$META_YOCTO_REV")
+
+    - checkout_repo https://git.openembedded.org/openembedded-core openembedded-core $OPENEMBEDDED_CORE_REV
+    - checkout_repo https://git.openembedded.org/bitbake openembedded-core/bitbake $BITBAKE_REV
+    - checkout_repo https://git.yoctoproject.org/meta-yocto meta-yocto $META_YOCTO_REV
 
     # Add MENDER_QA_REV, which is special, since it is this repository.
     - if echo "$CI_COMMIT_REF_NAME" | egrep '^pr_[0-9]+$'; then

--- a/scripts/generate_client_publish_job.py
+++ b/scripts/generate_client_publish_job.py
@@ -34,7 +34,7 @@ def getStableMetaMender():
     with urllib.request.urlopen(
         "https://raw.githubusercontent.com/mendersoftware/mender-qa/master/.gitlab-ci.yml"
     ) as stream:
-        return yaml.safe_load(stream)["variables"]["POKY_REV"]["value"]
+        return yaml.safe_load(stream)["variables"]["YOCTO_REV"]["value"]
 
 
 def generate(integration_repo, args):

--- a/scripts/gitlab_trigger_client_publish
+++ b/scripts/gitlab_trigger_client_publish
@@ -8,7 +8,7 @@ NUMBER_OF_MINOR_VERSIONS=3
 # Branch to use when building QEMU images to publish
 LATEST_STABLE_YOCTO_BRANCH=$(wget -q -O - \
   https://raw.githubusercontent.com/mendersoftware/mender-qa/master/.gitlab-ci.yml | \
-  sed -ne 's/.*POKY_REV:.*"\(.*\)"/\1/p')
+  sed -ne 's/.*YOCTO_REV:.*"\(.*\)"/\1/p')
 
 if [[ $# -eq 2 ]]; then
   version_to_publish=$1

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -641,7 +641,7 @@ build_and_test_client() {
             exit 1
         fi
 
-        source oe-init-build-env build-$board_name
+        source openembedded-core/oe-init-build-env build-$board_name
         cd ../
 
         prepare_build_config $machine_name $board_name


### PR DESCRIPTION
Poky won't be tagged for newer Yocto releases