### PR TITLE
ci: switch test container images to per-image registry paths

### DIFF
--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -2,7 +2,7 @@
 .template_build_test_acc:
   tags:
     - mender-qa-worker-client-acceptance-tests
-  image: mendersoftware/mender-test-containers:mender-client-acceptance-testing
+  image: registry.gitlab.com/northern.tech/mender/mender-test-containers/mender-client-acceptance-testing:master
   variables:
     DOCKER_BUILDKIT: 1
   needs:

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -66,7 +66,7 @@ build:client:docker:
   needs:
     - init:workspace
   allow_failure: false
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker

--- a/gitlab-pipeline/stage/release.yml
+++ b/gitlab-pipeline/stage/release.yml
@@ -95,7 +95,7 @@ release:mender-monitor:automatic:
   tags:
     - hetzner-amd-beefy
   stage: release
-  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers:docker-multiplatform-buildx-v1-master"
+  image: "registry.gitlab.com/northern.tech/mender/mender-test-containers/docker-multiplatform-buildx:master"
   services:
     - name: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/docker:28-dind
       alias: docker


### PR DESCRIPTION
Migrates all `mender-test-containers` image references from the legacy flat-tag format to the new per-image sub-repository format:

- `mender-test-containers:docker-multiplatform-buildx-v1-master` → `mender-test-containers/docker-multiplatform-buildx:master`
- `mendersoftware/mender-test-containers:mender-client-acceptance-testing` → `mender-test-containers/mender-client-acceptance-testing:master`

Ticket: QA-1603, QA-1605