### PR TITLE
ci: remove buildkit v0.17.3 pin from buildx setup

### DIFF
--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -91,7 +91,7 @@ build:client:docker:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
     # Prepare buildx
     - docker context create builder
-    - docker buildx create builder --use --driver-opt "image=moby/buildkit:v0.17.3,network=host" --buildkitd-flags '--debug --allow-insecure-entitlement network.host'
+    - docker buildx create builder --use --driver-opt network=host --buildkitd-flags '--debug --allow-insecure-entitlement network.host'
   script:
     - echo ${CI_REGISTRY_PASSWORD} | docker login --username ${CI_REGISTRY_USER} --password-stdin ${CI_REGISTRY}
     - cd virtual-device


### PR DESCRIPTION
QA-823 workaround (runc proc-mount failure on docker 27.4) is no longer needed.

Ticket: QA-1635