### PR TITLE
chore: checkout repos using https

### DIFF
--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -23,7 +23,6 @@ init:workspace:
     - ${CI_PROJECT_DIR}/scripts/github_pull_request_status pending "Gitlab ${CI_JOB_NAME} started" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     # Configure git to use HTTPS with token instead of SSH
-    - git config --global url."https://mender-test-bot:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/".insteadOf "git@github.com:"
     - git config --global --add url."https://mender-test-bot:${GITHUB_BOT_TOKEN_REPO_FULL}@github.com/".insteadOf "https://github.com/"
 
     # Bash function to checkout repos
@@ -119,7 +118,7 @@ init:workspace:
           "$MENDER_CONTAINER_MODULES_REV" != "latest" ]; then
     -   for repo in mender mender-connect mender-configure-module monitor-client mender-flash mender-container-modules mender-binary-delta mender-client-subcomponents; do
     -     checkout_repo
-            git@github.com:mendersoftware/$repo
+            https://github.com/mendersoftware/$repo.git
             go/src/github.com/mendersoftware/$repo
             $(repo_to_rev $repo)
     -   done
@@ -128,7 +127,7 @@ init:workspace:
     # Mender Gateway LTS
     - if [ "$MENDER_GATEWAY_REV" != "latest" ]; then
     -   checkout_repo
-          git@github.com:mendersoftware/mender-gateway
+          https://github.com/mendersoftware/mender-gateway.git
           go/src/github.com/mendersoftware/mender-gateway
           $MENDER_GATEWAY_REV
     - fi
@@ -136,7 +135,7 @@ init:workspace:
     # Mender Orchestrator LTS
     - if [ "$MENDER_ORCHESTRATOR_REV" != "latest" ]; then
     -   checkout_repo
-          git@github.com:mendersoftware/mender-orchestrator
+          https://github.com/mendersoftware/mender-orchestrator.git
           go/src/github.com/mendersoftware/mender-orchestrator
           $MENDER_ORCHESTRATOR_REV
     - fi
@@ -144,27 +143,27 @@ init:workspace:
     # Independent (yocto) components
     - if [ "$MENDER_ARTIFACT_REV" != "latest" ]; then
     -   checkout_repo
-          git@github.com:mendersoftware/mender-artifact
+          https://github.com/mendersoftware/mender-artifact.git
           go/src/github.com/mendersoftware/mender-artifact
           $MENDER_ARTIFACT_REV
     - fi
     - if [ "$MENDER_SNAPSHOT_REV" != "latest" ]; then
     -   checkout_repo
-          git@github.com:mendersoftware/mender-snapshot
+          https://github.com/mendersoftware/mender-snapshot.git
           go/src/github.com/mendersoftware/mender-snapshot
           $MENDER_SNAPSHOT_REV
     - fi
 
     # Add other repositories.
-    - checkout_repo git@github.com:openembedded/meta-openembedded.git meta-openembedded $META_OPENEMBEDDED_REV
-    - checkout_repo git://git.yoctoproject.org/meta-virtualization meta-virtualization $META_VIRTUALIZATION_REV
+    - checkout_repo https://git.openembedded.org/meta-openembedded meta-openembedded $META_OPENEMBEDDED_REV
+    - checkout_repo https://git.yoctoproject.org/meta-virtualization meta-virtualization $META_VIRTUALIZATION_REV
     - if [ "$BUILD_RASPBERRYPI3" = true ] || [ "$BUILD_RASPBERRYPI4" = true ]; then
     -   checkout_repo https://github.com/agherzan/meta-raspberrypi.git meta-raspberrypi $META_RASPBERRYPI_REV
     - fi
 
     # For meta-mender we need the full git history for this logic to work:
     # https://github.com/mendersoftware/meta-mender/blob/dd0f848f260810e08b98d2a1915f734bf02a64b1/tests/acceptance/test_uboot_automation.py#L68-L83
-    - git clone git@github.com:mendersoftware/meta-mender meta-mender
+    - git clone https://github.com/mendersoftware/meta-mender.git meta-mender
     - |
       (
         cd meta-mender &&


### PR DESCRIPTION
Not all places were cloning from git@github.com, so SSH would still be used, e.g.  git://git.yoctoproject.org. Instead of changing from ssh to https behind the scenes, we now explcitly clone through https and only insert `GITHUB_BOT_TOKEN_REPO_FULL` when using "https://github.com/".

Ticket: QA-1580