### PR TITLE
chore: Update mender-artifact arguments to match latest version

### DIFF
--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -122,8 +122,8 @@ modify_artifact() {
     device_types="$(mender-artifact read $old_artifact | sed -rne "/^ *Compatible (devices|types):/ {
         s/^[^[]*\\[//;
         s/][^]]*$//;
-        s/ +/ -t /g;
-        s/^/-t /;
+        s/ +/ -c /g;
+        s/^/-c /;
         p;
     }")"
 


### PR DESCRIPTION
In the latest version of mender-artifact parameter `--device-type` has been replaced with `--compatible-types`. This requires update all mender-artifact calls which still use old version of argument name.

Ticket: MEN-9344