### PR TITLE
fix: Run trigger:generate-gitlab-integration-rev in a Debian 13 container

### DIFF
--- a/gitlab-pipeline/stage/trigger-integration.yml
+++ b/gitlab-pipeline/stage/trigger-integration.yml
@@ -41,6 +41,7 @@ trigger:generate-gitlab-integration-rev:
   rules:
     - if: $RUN_INTEGRATION_TESTS == "true"
   needs: []
+  image: ${CI_DEPENDENCY_PROXY_DIRECT_GROUP_IMAGE_PREFIX}/debian:13
   script:
   # Convert INTEGRATION_REV on format `pull/0000/head` to `pr_0000` to specify which gitlab branch to trigger
   - |


### PR DESCRIPTION
The job requires Bash so it cannot run on an arbitrary default container.

Ticket: none
Changelog: none