### PR TITLE
fix: Pending status update when pipeline is green

### DIFF
--- a/gitlab-pipeline/stage/yocto-build-n-test.yml
+++ b/gitlab-pipeline/stage/yocto-build-n-test.yml
@@ -37,13 +37,11 @@ build:client:qemu:
     - fi
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -72,7 +70,7 @@ test:acceptance:qemux86_64:uefi_grub:
     - tar -czf qemu-artifacts.tar.gz --strip-components=2 $WORKSPACE/qemux86-64-uefi-grub/{*.uefiimg,*.sdimg,*.wic,ovmf.qcow2,bzImage} || true
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub.xml
@@ -89,8 +87,6 @@ test:acceptance:qemux86_64:uefi_grub:
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
 
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -121,7 +117,7 @@ test:acceptance:qemux86_64:uefi_grub:cross-platform:
     - cp $WORKSPACE/qemux86-64-uefi-grub/qemux86-64-uefi-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_QEMUX86_64_UEFI_GRUB" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_uefi_grub_cross_platform.xml
@@ -137,8 +133,6 @@ test:acceptance:qemux86_64:uefi_grub:cross-platform:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -169,7 +163,7 @@ test:acceptance:vexpress_qemu:
     - cp $WORKSPACE/vexpress-qemu/vexpress-qemu_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_VEXPRESS_QEMU" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu.xml
@@ -191,8 +185,6 @@ test:acceptance:vexpress_qemu:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -223,7 +215,7 @@ test:acceptance:qemux86_64:bios_grub:
     - cp $WORKSPACE/qemux86-64-bios-grub/qemux86-64-bios-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub.xml
@@ -245,8 +237,6 @@ test:acceptance:qemux86_64:bios_grub:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -277,7 +267,7 @@ test:acceptance:qemux86_64:bios_grub_gpt:
     - cp $WORKSPACE/qemux86-64-bios-grub-gpt/qemux86-64-bios-grub-gpt_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_QEMUX86_64_BIOS_GRUB_GPT" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_qemux86_64_bios_grub_gpt.xml
@@ -299,8 +289,6 @@ test:acceptance:qemux86_64:bios_grub_gpt:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -331,7 +319,7 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
     - cp $WORKSPACE/vexpress-qemu-uboot-uefi-grub/vexpress-qemu-uboot-uefi-grub_release_1_*.mender stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_uboot_uefi_grub.xml
@@ -353,8 +341,6 @@ test:acceptance:vexpress_qemu:uboot_uefi_grub:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -388,7 +374,7 @@ test:acceptance:vexpress_qemu:flash:
     - cp $WORKSPACE/vexpress-qemu-flash/core-image-minimal-vexpress-qemu-flash.ubifs stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - if [ "$TEST_VEXPRESS_QEMU_FLASH" = "true" ]; then
     -   cp $WORKSPACE/meta-mender/tests/acceptance/results.xml results_accep_vexpress_qemu_flash.xml
@@ -410,8 +396,6 @@ test:acceptance:vexpress_qemu:flash:
     - echo "Gathering logs from tested image..."
     - cp -r /tmp/journalctl* stage-artifacts/
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -440,14 +424,12 @@ build:acceptance:beagleboneblack:
     - cp $WORKSPACE/beagleboneblack/mender-beagleboneblack_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -474,14 +456,12 @@ build:acceptance:raspberrypi3:
     - cp $WORKSPACE/raspberrypi3/mender-raspberrypi3_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w
@@ -508,14 +488,12 @@ build:acceptance:raspberrypi4:
     - cp $WORKSPACE/raspberrypi4/mender-raspberrypi4_*.sdimg.gz stage-artifacts/
   after_script:
     - export WORKSPACE=$(realpath ${CI_PROJECT_DIR}/..)
-    - if [ "$(cat /JOB_RESULT.txt)" != "success" ]; then ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"; fi
+    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
     - cp /var/log/sysstat/sysstat.log .
     - sadf sysstat.log -g -- -qurbS > sysstat.svg
 
     - ls -lh stage-artifacts/
-    # Post job status
-    - ${CI_PROJECT_DIR}/scripts/github_pull_request_status $(cat /JOB_RESULT.txt) "Gitlab ${CI_JOB_NAME} finished" "${CI_JOB_URL}" "${CI_JOB_NAME}/${INTEGRATION_REV}"
 
   artifacts:
     expire_in: 2w


### PR DESCRIPTION
Fix for infinite pending status updates on GitHub despite green pipeline caused by premature exit in jobs' after_script. Added 'set +e' to ensure status is reported at the end.

Ticket: QA-1652