### PR TITLE
chore: swap chore with fix for default dependency updates

### DIFF
--- a/Documentation/dependency-updates.md
+++ b/Documentation/dependency-updates.md
@@ -121,7 +121,7 @@ batch-merge on a Friday afternoon.
 
 ### Commit messages
 
-Every dependency update commit follows the pattern `chore(deps): <description>`. CI file
+Every dependency update commit follows the pattern `fix(deps): <description>`. CI file
 updates use `ci:` instead. This keeps dependency bumps out of the product changelog
 and prevents them from triggering unintended releases through release-please.
 

--- a/renovate.json5.sample
+++ b/renovate.json5.sample
@@ -24,12 +24,12 @@
   "reviewersFromCodeOwners": true,
   // "reviewers": ["team:backend-dependabot-reviewers"],
 
-  // Commit message format: chore(deps): <description>
+  // Commit message format: fix(deps): <description>
   // This matches the existing Dependabot convention in the codebase and keeps
   // dependency bumps out of the product changelog. CI file updates use ci:
   // instead - see the packageRules override below.
   "semanticCommits": "enabled",
-  "semanticCommitType": "chore",
+  "semanticCommitType": "fix",
   "semanticCommitScope": "deps",
 
   // PRs open overnight between Monday and Tuesday (22:00-06:00 UTC) - fallback for
@@ -117,6 +117,18 @@
   ],
 
   "packageRules": [
+
+    // config:recommended pulls in :semanticPrefixFixDepsChoreOthers, which defaults
+    // semanticCommitType to "chore" for any dep whose manager doesn't tag it with an
+    // npm/pip-style "dependencies"/"require" depType - that's every terraform, docker
+    // and kubernetes dep. Without this override, those PRs silently open as
+    // chore(deps) even though semanticCommitType above says "fix". This rule must
+    // come BEFORE the gitlabci override below - packageRules apply in order and the
+    // last match wins, so gitlabci keeps its own "ci" type.
+    {
+      "matchPackageNames": ["*"],
+      "semanticCommitType": "fix"
+    },
 
     // CI file updates get commit type "ci" instead of "chore".
     // Keeps gitlabci image bumps in the ci: changelog section, not deps.


### PR DESCRIPTION
By default renovate uses fix(deps) to flag a dependency update, instead of chore(deps).