### PR TITLE
chore: integrate mender-delta-container-modules into yocto builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,10 @@ variables:
     value: "main"
     description: |-
       Version of mender-container-modules
+  MENDER_DELTA_CONTAINER_MODULES_REV:
+    value: "main"
+    description: |-
+      Version of mender-delta-container-modules
 
   # Mender Gateway LTS
   MENDER_GATEWAY_REV:

--- a/gitlab-pipeline/shared/build_and_test_acceptance.yml
+++ b/gitlab-pipeline/shared/build_and_test_acceptance.yml
@@ -30,6 +30,8 @@
       optional: true
     - job: build:mender-binary-delta
       optional: true
+    - job: build:delta-docker-compose
+      optional: true
   before_script:
     # collect cpu, load avg, memory and io usage every 2 secs forever
     # use 'sar' from sysstat to render the result file manually

--- a/gitlab-pipeline/stage/build.yml
+++ b/gitlab-pipeline/stage/build.yml
@@ -40,6 +40,17 @@ include:
         # mender-binary-delta is not an independent component (subcomponent of Mender Client LTS).
         # We build it as long as neither the mender-binary-delta nor the mender revision is set to latest
         - if: $MENDER_BINARY_DELTA_REV != "latest" || $MENDER_REV != "latest"
+  # mender-delta-container-modules
+  - component: gitlab.com/Northern.tech/Mender/mender-delta-container-modules/build-delta-docker-compose@main
+    inputs:
+      job_name: build:delta-docker-compose
+      before_script:
+        - *workspace_restore
+      architectures:
+        - x86_64
+        - arm
+      rules:
+        - if: $MENDER_DELTA_CONTAINER_MODULES_REV != "latest"
   # mender-monitor
   - component: gitlab.com/Northern.tech/Mender/monitor-client/build-mender-monitor@master
     inputs:

--- a/gitlab-pipeline/stage/init.yml
+++ b/gitlab-pipeline/stage/init.yml
@@ -153,6 +153,14 @@ init:workspace:
           $MENDER_ORCHESTRATOR_REV
     - fi
 
+    # Mender Delta Container Modules
+    - if [ "$MENDER_DELTA_CONTAINER_MODULES_REV" != "latest" ]; then
+    -   checkout_repo
+          https://github.com/mendersoftware/mender-delta-container-modules.git
+          go/src/github.com/mendersoftware/mender-delta-container-modules
+          $MENDER_DELTA_CONTAINER_MODULES_REV
+    - fi
+
     # Independent (yocto) components
     - if [ "$MENDER_ARTIFACT_REV" != "latest" ]; then
     -   checkout_repo

--- a/scripts/yocto-build-and-test.sh
+++ b/scripts/yocto-build-and-test.sh
@@ -196,7 +196,7 @@ repo_to_recipe() {
 # Repo is closed source (installs prebuilt tarball)
 is_closed_source() {
     case "$1" in
-    mender-binary-delta|monitor-client|mender-gateway)
+    mender-binary-delta|monitor-client|mender-gateway|mender-delta-container-modules)
         return 0
         ;;
     *)
@@ -383,6 +383,34 @@ EOF
     cat >> $BUILDDIR/conf/local.conf <<EOF
 PREFERRED_VERSION:pn-mender-orchestrator-support = "$version"
 EOF
+
+    if has_recipe mender-delta-container-modules; then
+        if has_local_checkout mender-delta-container-modules; then
+            # Not going through use_closed_source_tarball: the tarball prefix
+            # (delta-docker-compose) differs from the PN, and the update module
+            # is a shell script with no version string to probe.
+            local arch=$(bitbake -e | grep '^TARGET_ARCH=' | cut -d'"' -f2)
+            local filename=$(find $WORKSPACE/stage-artifacts/mender-delta-container-modules/${arch}/ -maxdepth 1 -name "delta-docker-compose-*.tar.xz" 2>/dev/null | head -n1)
+            cat >> $BUILDDIR/conf/local.conf <<EOF
+PREFERRED_VERSION:pn-mender-delta-container-modules = "main-git%"
+SRC_URI:pn-mender-delta-container-modules = "file:///$filename"
+EOF
+        else
+            local version="$MENDER_DELTA_CONTAINER_MODULES_REV"
+            if [ -z "$version" -o "$version" = "latest" ]; then
+                version=main
+            fi
+            local preferred_version="$version"
+            if [ "$version" = "main" ]; then
+                preferred_version="main-git%"
+            fi
+            s3cmd get s3://${S3_BUCKET_NAME}/mender-delta-container-modules/yocto/${version}/delta-docker-compose-${version}.tar.xz $WORKSPACE/downloads
+            cat >> $BUILDDIR/conf/local.conf <<EOF
+PREFERRED_VERSION:pn-mender-delta-container-modules = "$preferred_version"
+SRC_URI:pn-mender-delta-container-modules = "file:///$WORKSPACE/downloads/delta-docker-compose-${version}.tar.xz"
+EOF
+        fi
+    fi
 
     # Use network cache if present, if not, use local cache.
     if [ -d /mnt/sstate-cache ]; then


### PR DESCRIPTION
The new meta-mender recipe consumes the delta-docker-compose tarball, so follow the same pattern as the other closed-source components

Ticket: MEN-9448