### PR TITLE
fix(docker): Workaround for missing manifest error

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -294,6 +294,11 @@ variables:
     description: |-
       Marker to identify nightly builds
 
+  # Workaround for https://github.com/moby/buildkit/issues/7007
+  BUILDX_NO_DEFAULT_ATTESTATIONS:
+    value: "true"
+    description: "Publish docker images without attestations"
+
   # Debugging options
   WAIT_IN_STAGE_INIT:
     value: ""


### PR DESCRIPTION
Set BUILDX_NO_DEFAULT_ATTESTATIONS to avoid issue with publishing images to registry, introduced in docker 29.7.
Relevant docker issue tracking: https://github.com/moby/buildkit/issues/7007